### PR TITLE
add --relabel option to --shuffle #121

### DIFF
--- a/src/shuffle.cc
+++ b/src/shuffle.cc
@@ -100,8 +100,15 @@ void shuffle()
   progress_init("Writing output", passed);
   for(int i=0; i<passed; i++)
     {
-      db_fprint_fasta(fp_output, deck[i]);
-      progress_update(i);
+      if (opt_relabel) {
+        fprintf(fp_output, ">%s%ld\n", opt_relabel, i+1);
+        db_fprint_fasta_seq_only(fp_output, deck[i]);
+        progress_update(i);
+      }
+      else {
+        db_fprint_fasta(fp_output, deck[i]);
+        progress_update(i);      	
+      }
     }
   progress_done();
 


### PR DESCRIPTION
Implements `--relabel` in `--shuffle` to address #121 

I there anywhere I should document this addition?

---

Other functions that support relabeling often support `--sizeout` as shown here:
https://github.com/torognes/vsearch/blob/master/src/derep.cc#L383-L391

Should `--sizeout` also be supported by `--shuffle`?