### PR TITLE
disable default CXXFLAGS

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -8,6 +8,11 @@ AC_LANG([C++])
 AC_CONFIG_SRCDIR([src/vsearch.cc])
 AC_CONFIG_HEADERS([config.h])
 
+# disable default CXXFLAGS
+if test -z $CXXFLAGS; then
+  CXXFLAGS=''
+fi
+
 # Checks for programs.
 AC_PROG_CXX
 AC_PROG_RANLIB


### PR DESCRIPTION
Hi @torognes , I've disabled the default `CXXFLAGS` which were `-O2 -g`. Before that, all objects were built using the CXXFLAGS provided in src/Makefile.am **PLUS** the `-O2 -g` flags. I'm not sure what the precedence is when using different -O flags and perhaps -O3  still had precedence, but for clarity I've removed the defaults.

Note that now both libcpu_sse2.a and libcpu_ssse3.a are *not* compiled with any optimization flags (not sure if this was intentional). Prior this PR, both were compiled with the defaults (`-O2 -g`).
The clean way to add optimization flags now would be to alter the `libcpu_sse2_a_CXXFLAGS` and `libcpu_ssse3_a_CXXFLAGS` in `src/Makefile.am`.

Tomas