### PR TITLE
Add fastq_maxdiffpct option (% difference for merging pairs)

### DIFF
--- a/src/mergepairs.cc
+++ b/src/mergepairs.cc
@@ -446,6 +446,8 @@ double overlap_score(merge_data_t * ip,
           diffs++;
           if (diffs > opt_fastq_maxdiffs)
             return -1000.0;
+          if (100.0 * diffs / overlap > opt_fastq_maxdiffpct)
+            return -1000.0;
         }
     }
   return score;

--- a/src/vsearch.cc
+++ b/src/vsearch.cc
@@ -191,6 +191,7 @@ int64_t opt_fasta_width;
 int64_t opt_fastq_ascii;
 int64_t opt_fastq_asciiout;
 int64_t opt_fastq_maxdiffs;
+int64_t opt_fastq_maxdiffpct;
 int64_t opt_fastq_maxlen;
 int64_t opt_fastq_maxmergelen;
 int64_t opt_fastq_maxns;
@@ -572,6 +573,7 @@ void args_init(int argc, char **argv)
   opt_fastq_eestats = 0;
   opt_fastq_filter = 0;
   opt_fastq_maxdiffs = 5;
+  opt_fastq_maxdiffpct = 100;
   opt_fastq_maxee = DBL_MAX;
   opt_fastq_maxee_rate = DBL_MAX;
   opt_fastq_maxlen = LONG_MAX;
@@ -901,6 +903,7 @@ void args_init(int argc, char **argv)
     {"mothur_shared_out",     required_argument, 0, 0 },
     {"biomout",               required_argument, 0, 0 },
     {"fastq_trunclen_keep",   required_argument, 0, 0 },
+    {"fastq_maxdiffpct",        required_argument, 0, 0 },
     { 0, 0, 0, 0 }
   };
 
@@ -1679,6 +1682,10 @@ void args_init(int argc, char **argv)
           opt_fastq_trunclen_keep = args_getlong(optarg);
           break;
 
+        case 182:
+          opt_fastq_maxdiffpct = args_getlong(optarg);
+          break;
+
         default:
           fatal("Internal error in option parsing");
         }
@@ -2162,6 +2169,7 @@ void cmd_help()
               "  --fastq_allowmergestagger   Allow merging of staggered reads\n"
               "  --fastq_ascii INT           FASTQ input quality score ASCII base char (33)\n"
               "  --fastq_maxdiffs INT        maximum number of different bases in overlap (5)\n"
+              "  --fastq_maxdiffpct INT      maximum percentage of different bases in overlap (100)\n"
               "  --fastq_maxee REAL          maximum expected error value for merged sequence\n"
               "  --fastq_maxmergelen         maximum length of entire merged sequence\n"
               "  --fastq_maxns INT           maximum number of N's\n"

--- a/src/vsearch.h
+++ b/src/vsearch.h
@@ -324,6 +324,7 @@ extern int64_t opt_fasta_width;
 extern int64_t opt_fastq_ascii;
 extern int64_t opt_fastq_asciiout;
 extern int64_t opt_fastq_maxdiffs;
+extern int64_t opt_fastq_maxdiffpct;
 extern int64_t opt_fastq_maxlen;
 extern int64_t opt_fastq_maxmergelen;
 extern int64_t opt_fastq_maxns;


### PR DESCRIPTION
Thanks for this useful tool! Here is a simple feature that improves compatibility with USEARCH and helps when merging read pairs from variable-length amplicons:

I've added a `-fastq_maxdiffpct` parameter for the `fastq_mergepairs` option, based on the parameter of the same name from USEARCH (see [the manual page](http://drive5.com/usearch/manual/merge_options.html)). When merging FASTQ reads, this parameter sets the maximum mismatches as a percentage of the total overlap length (in addition to the absolute number of mismatches `-fastq_maxdiffs`).

While USEARCH sets the default value of this parameter to 5 (according to the manual), I've set the default as 100 so the output of the algorithm won't change unless the user sets the parameter to a lower percentage.

The percentage difference option is useful for variable-length amplicons where the overlap is sometimes very long; it seems preferable to allow more mismatches in a 200-base overlap versus a 20-base overlap. We are currently using this option to merge amplicon reads from the fungal ITS1 region.