### PR TITLE
MAINT: Add const modifier.

### DIFF
--- a/src/abundance.cc
+++ b/src/abundance.cc
@@ -83,7 +83,7 @@ bool header_find_attribute(const char * header,
 
   while (i < hlen - alen)
     {
-      char * r = strstr(header + i, attribute);
+      const char * r = strstr(header + i, attribute);
 
       /* no match */
       if (r == NULL)


### PR DESCRIPTION
The function `strstr` on my system (gcc 4.8.5 on centos 7) returns a `const char*` if the input arguments are also `const char *`. I needed this small modification to get the sources to compile.