### PR TITLE
Updating CFLAGS

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -14,8 +14,8 @@ MACOSX_DEPLOYMENT_TARGET="10.7"
 
 # Set default gcc and g++ options
 
-CFLAGS='-g'
-CXXFLAGS='-g'
+CFLAGS='-g -march=native'
+CXXFLAGS='-g -march=native'
 
 # Checks for programs.
 AC_PROG_CXX


### PR DESCRIPTION
Updates CFLAGS for autotools to correctly enable CPU features.

On Mac OS 10.14, GCC shipped with Xcode fails to enable SSSE3 with default configuration. Issue is solved with the addition of `-march=native` flag.