### PR TITLE
Collecting CFLAGS to a central location

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -14,8 +14,8 @@ MACOSX_DEPLOYMENT_TARGET="10.7"
 
 # Set default gcc and g++ options
 
-CFLAGS='-g -march=native'
-CXXFLAGS='-g -march=native'
+CFLAGS='-Wall -O3 -g -march=native'
+CXXFLAGS="${CFLAGS}"
 
 # Checks for programs.
 AC_PROG_CXX

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -1,13 +1,5 @@
 bin_PROGRAMS = $(top_builddir)/bin/vsearch
 
-if TARGET_PPC
-AM_CXXFLAGS=-Wall -Wsign-compare -O3 -g -mcpu=power8
-else
-AM_CXXFLAGS=-Wall -Wsign-compare -O3 -g
-endif
-
-AM_CFLAGS=$(AM_CXXFLAGS)
-
 export MACOSX_DEPLOYMENT_TARGET
 
 VSEARCHHEADERS=\
@@ -65,9 +57,8 @@ libcpu_a_SOURCES = cpu.cc $(VSEARCHHEADERS)
 noinst_LIBRARIES = libcpu.a libcityhash.a
 else
 libcpu_sse2_a_SOURCES = cpu.cc $(VSEARCHHEADERS)
-libcpu_sse2_a_CXXFLAGS = $(AM_CXXFLAGS) -msse2
 libcpu_ssse3_a_SOURCES = cpu.cc $(VSEARCHHEADERS)
-libcpu_ssse3_a_CXXFLAGS = $(AM_CXXFLAGS) -mssse3 -DSSSE3
+libcpu_ssse3_a_CXXFLAGS = -DSSSE3
 noinst_LIBRARIES = libcpu_sse2.a libcpu_ssse3.a libcityhash.a
 endif
 
@@ -75,13 +66,13 @@ libcityhash_a_SOURCES = city.cc city.h
 
 if TARGET_WIN
 
-libcityhash_a_CXXFLAGS = -Wall -Wno-sign-compare -O3 -g -D_MSC_VER
+libcityhash_a_CXXFLAGS = -Wno-sign-compare -D_MSC_VER
 __top_builddir__bin_vsearch_LDFLAGS = -static
 __top_builddir__bin_vsearch_LDADD = libregex.a libcityhash.a libcpu_ssse3.a libcpu_sse2.a
 
 else
 
-libcityhash_a_CXXFLAGS = -Wall -Wno-sign-compare -O3 -g
+libcityhash_a_CXXFLAGS = -Wno-sign-compare
 
 if TARGET_PPC
 __top_builddir__bin_vsearch_LDADD = libcityhash.a libcpu.a


### PR DESCRIPTION
Collects the CFLAGS to a central location so that the debug flag `-g`,
the compiler optimization flag `-Ox`, and the warning flag `-Wx` would
be uniform accross all files.