### PR TITLE
Add link to the BioConda package

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,6 +106,8 @@ Windows: You will now have the binary distribution in a folder called `vsearch-2
 
 **QIIME 2 plugin** Thanks to the [QIIME 2](https://github.com/qiime2) team, there is now a plugin called [q2-vsearch](https://github.com/qiime2/q2-vsearch) for [QIIME 2](https://qiime2.org).
 
+**Conda package** Thanks to the [BioConda](https://bioconda.github.io/) team, there is now a [vsearch package](https://anaconda.org/bioconda/vsearch) in [Conda](https://conda.io/).
+
 **Homebrew package** Thanks to [Torsten Seeman](https://github.com/tseemann), a [vsearch package](https://github.com/Homebrew/homebrew-science/pull/2409) for [Homebrew](http://brew.sh/) has been made.
 
 **Debian package** Thanks to the [Debian Med](https://www.debian.org/devel/debian-med/) team, there is now a [vsearch](https://packages.debian.org/sid/vsearch) package in [Debian](https://www.debian.org/).


### PR DESCRIPTION
The recipe source is here:

https://github.com/bioconda/bioconda-recipes/tree/master/recipes/vsearch

It explicitly declares build-time dependencies on the compression libraries, so that should all just work.