### PR TITLE
 Force weak_id to be a reasonable value when cluster_unoise (0.9)

### DIFF
--- a/src/vsearch.cc
+++ b/src/vsearch.cc
@@ -2048,8 +2048,11 @@ void args_init(int argc, char **argv)
   if (commands > 1)
     fatal("More than one command specified");
 
-  if (opt_weak_id > opt_id)
-    opt_weak_id = opt_id;
+  if (opt_cluster_unoise)
+    opt_weak_id = 0.90;
+  else
+    if (opt_weak_id > opt_id)
+      opt_weak_id = opt_id;
 
   if (opt_maxrejects == -1)
     {
@@ -2871,7 +2874,7 @@ void cmd_cluster()
   if (!opt_cluster_unoise)
     if ((opt_id < 0.0) || (opt_id > 1.0))
       fatal("Identity between 0.0 and 1.0 must be specified with --id");
-
+ 
   if (opt_cluster_fast)
     cluster_fast(cmdline, progheader);
   else if (opt_cluster_smallmem)


### PR DESCRIPTION
Now it really ignores the `--id` param. I think that `opt_weak_id=0.9` for UNOISE is a reasonable choice. Related to #283 and https://groups.google.com/d/msg/vsearch-forum/ws7NEP68gO8/DZX6zT16BAAJ