### PR TITLE
fix reverse complement sequence hash when header used: if header hash…

### DIFF
--- a/src/derep.cc
+++ b/src/derep.cc
@@ -387,9 +387,10 @@ void derep(char * input_filename, bool use_header)
         collision when the number of sequences is about 5e9.
       */
 
+      uint64_t hash_header = HASH(header, headerlen);
       uint64_t hash = HASH(seq_up, seqlen);
       if (use_header)
-        hash ^= HASH(header, headerlen);
+        hash ^= hash_header;
       uint64_t j = hash & hash_mask;
       struct bucket * bp = hashtable + j;
 
@@ -409,6 +410,8 @@ void derep(char * input_filename, bool use_header)
           /* check minus strand as well */
 
           uint64_t rc_hash = HASH(rc_seq_up, seqlen);
+          if (use_header)
+              rc_hash ^= hash_header;
           uint64_t k = rc_hash & hash_mask;
           struct bucket * rc_bp = hashtable + k;
 


### PR DESCRIPTION
fix reverse complement sequence hash when header used:

 if header hash needed to be combined into seq hash, then reverse complement sequence hash should also combine header hash