### PR TITLE
fix two GCC 10.2 format warnings

### DIFF
--- a/src/derep.cc
+++ b/src/derep.cc
@@ -972,11 +972,11 @@ void derep(char * input_filename, bool use_header)
           if (opt_relabel)
             fprintf(fp_tabbedout,
                     "%s\t%s%" PRIu64 "\t%" PRIu64 "\t%" PRIu64 "\t%u\t%s\n",
-                    hh, opt_relabel, i + 1, i, 0ULL, bp->count, hh);
+                    hh, opt_relabel, i + 1, i, 0UL, bp->count, hh);
           else
             fprintf(fp_tabbedout,
                     "%s\t%s\t%" PRIu64 "\t%" PRIu64 "\t%u\t%s\n",
-                    hh, hh, i, 0ULL, bp->count, hh);
+                    hh, hh, i, 0UL, bp->count, hh);
 
           uint64_t j = 1;
           for (unsigned int next = nextseqtab[bp->seqno_first];


### PR DESCRIPTION
```
derep.cc:974:21: warning: format ‘%lu’ expects argument of type ‘long unsigned int’, but argument 7 has type ‘long long unsigned int’ [-Wformat=]
  974 |                     "%s\t%s%" PRIu64 "\t%" PRIu64 "\t%" PRIu64 "\t%u\t%s\n",
      |                     ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
  975 |                     hh, opt_relabel, i + 1, i, 0ULL, bp->count, hh);
      |                                                ~~~~
      |                                                |
      |                                                long long unsigned int
derep.cc:978:21: warning: format ‘%lu’ expects argument of type ‘long unsigned int’, but argument 6 has type ‘long long unsigned int’ [-Wformat=]
  978 |                     "%s\t%s\t%" PRIu64 "\t%" PRIu64 "\t%u\t%s\n",
      |                     ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
  979 |                     hh, hh, i, 0ULL, bp->count, hh);
      |                                ~~~~
      |                                |
      |                                long long unsigned int
```