### PR TITLE
Check for SSSE3 should be build time, not run time.

### DIFF
--- a/src/searchcore.cc
+++ b/src/searchcore.cc
@@ -234,16 +234,11 @@ void search_topscores(struct searchinfo_s * si)
       if (bitmap)
         {
 #ifdef __x86_64__
-          if (ssse3_present)
-            {
-              increment_counters_from_bitmap_ssse3(si->kmers,
-                                                   bitmap, indexed_count);
-            }
-          else
-            {
-              increment_counters_from_bitmap_sse2(si->kmers,
-                                                  bitmap, indexed_count);
-            }
+#ifdef SSSE3
+          increment_counters_from_bitmap_ssse3(si->kmers, bitmap, indexed_count);
+#else
+          increment_counters_from_bitmap_sse2(si->kmers, bitmap, indexed_count);
+#endif // SSSE3
 #else
           increment_counters_from_bitmap(si->kmers, bitmap, indexed_count);
 #endif

--- a/src/vsearch.cc
+++ b/src/vsearch.cc
@@ -4897,6 +4897,7 @@ void cmd_help()
               "  --tabbedout FILENAME        write cluster info to tsv file for fastx_uniques\n"
               "  --topn INT                  output only n most abundant sequences after derep\n"
               "  --uc FILENAME               filename for UCLUST-like dereplication output\n"
+              "  --xee                       remove expected errors (ee) info from output\n"
               "  --xsize                     strip abundance information in derep output\n"
               "\n"
               "FASTA to FASTQ conversion\n"


### PR DESCRIPTION
In `cpu.cc`, we use preprocessor directives to discover SSSE3 vs SSE2, but in `searchcore.cc` we use a runtime variable based on cpuid.  This changeset makes it match by using preprocessor in both places. This makes the code more resilient in different environments, or if someone forgot to pass `-DSSSE3` on the build line.

Also, added one switch which was missing from help printout. There are others that are missing, like `--sample` but I don't know what that does.