### PR TITLE
Include new labels in uc output for dereplication if --relabel option provided

### DIFF
--- a/man/vsearch.1
+++ b/man/vsearch.1
@@ -1375,7 +1375,7 @@ Not used, always set to '*'.
 .IP \n+[step].
 Label of the query sequence (H), or of the centroid sequence (S, C).
 .IP \n+[step].
-Label of the centroid sequence (H), or set to '*' (S, C).
+Label of the centroid sequence (H), or new label, if a \-\-relabel option was given, or '*' (S, C).
 .RE
 .RE
 .RE

--- a/src/util.cc
+++ b/src/util.cc
@@ -393,6 +393,24 @@ void fprint_seq_digest_md5(FILE * fp, char * seq, int seqlen)
   fprintf(fp, "%s", digest);
 }
 
+char * seq_digest_md5(char * seq, int seqlen)
+{
+  char digest[LEN_HEX_DIG_MD5];
+  get_hex_seq_digest_md5(digest, seq, seqlen);
+  char * digest_str = (char *) xmalloc(33);
+  sprintf(digest_str, "%s", digest);
+  return digest_str;
+}
+
+char * seq_digest_sha1(char * seq, int seqlen)
+{
+  char digest[LEN_HEX_DIG_SHA1];
+  get_hex_seq_digest_sha1(digest, seq, seqlen);
+  char * digest_str = (char *) xmalloc(41);
+  sprintf(digest_str, "%s", digest);
+  return digest_str;
+}
+
 FILE * fopen_input(const char * filename)
 {
   /* open the input stream given by filename, but use stdin if name is - */

--- a/src/util.h
+++ b/src/util.h
@@ -107,6 +107,9 @@ void get_hex_seq_digest_md5(char * hex, char * seq, int seqlen);
 
 void fprint_seq_digest_sha1(FILE * fp, char * seq, int seqlen);
 void fprint_seq_digest_md5(FILE * fp, char * seq, int seqlen);
+char * seq_digest_sha1(char * seq, int seqlen);
+char * seq_digest_md5(char * seq, int seqlen);
+
 
 FILE * fopen_input(const char * filename);
 FILE * fopen_output(const char * filename);


### PR DESCRIPTION
With this update, if --relabel, --relabel_sha1 or --relabel_md5 are provided with a --derep* command, the new labels of the sequences will be included in the UC output file (column 10).   For any 'H' record types, the target will be the new label.   For any S or C record types, the target will be the new label and column 9 (label of query sequence) will be the original label of the sequence.