### PR TITLE
Write missing-abundance warning to logfile in rereplicate.cc

### DIFF
--- a/src/rereplicate.cc
+++ b/src/rereplicate.cc
@@ -130,7 +130,7 @@ auto rereplicate(struct Parameters const & parameters) -> void
     {
       if (missing_abundance)
         {
-          std::fprintf(stderr, "WARNING: Missing abundance information for some input sequences, assumed 1\n");
+          std::fprintf(fp_log, "WARNING: Missing abundance information for some input sequences, assumed 1\n");
         }
       std::fprintf(fp_log, "Rereplicated %" PRId64 " reads from %" PRId64 " amplicons\n", n_reads, n_amplicons);
     }


### PR DESCRIPTION
In the --log branch of rereplicate(), the "Missing abundance information" warning was written to stderr instead of the log file handle. As a result the warning was printed to stderr twice (once in the !opt_quiet branch and once here) and never reached the --log file, while the summary line immediately below it is correctly written to fp_log.

Write the warning to fp_log so it lands in the log file and is not duplicated on stderr.


Claude-Session: https://claude.ai/code/session_01H6v7rX4pGLAL5BT2EWWxMM