### PR TITLE
Fix off-by-one in MSA consensus ;length= output

### DIFF
--- a/src/msa.cc
+++ b/src/msa.cc
@@ -490,7 +490,7 @@ auto print_consensus_sequence(std::FILE *fp_consout, std::vector<char> & cons_v,
   fasta_print_general(fp_consout,
                       "centroid=",
                       cons_v.data(),
-                      static_cast<int>(cons_v.size()),
+                      static_cast<int>(cons_v.size() - 1),  // exclude the '\0' terminator slot
                       db_getheader(centroid_seqno),
                       static_cast<int>(db_getheaderlen(centroid_seqno)),
                       totalabundance,


### PR DESCRIPTION
print_consensus_sequence() passed cons_v.size() as the sequence length to fasta_print_general(), but cons_v is sized conslen + 1 — the extra slot holds the '\0' terminator. With --consout --lengthout this made the ;length= field of every cluster's consensus one larger than the actual consensus (the sequence body itself is unaffected, since it is printed via "%.*s" and stops at the embedded NUL).

Pass cons_v.size() - 1 so the reported length matches the true residue count, consistent with every other fasta_print_general() caller. cons_v always contains at least the terminator, so the subtraction is safe.


Claude-Session: https://claude.ai/code/session_01H6v7rX4pGLAL5BT2EWWxMM