### PR TITLE
Saturate k-mer match counter to avoid wraparound dropping hits

### DIFF
--- a/src/searchcore.cc
+++ b/src/searchcore.cc
@@ -306,7 +306,16 @@ auto search_topscores(struct searchinfo_s * searchinfo) -> void
           auto const count = dbindex_getmatchcount(kmer);
           for (auto j = 0U; j < count; j++)
             {
-              searchinfo->kmers[list[j]]++;
+              /* Saturate at INT16_MAX (32767) rather than letting the
+                 unsigned-short counter wrap at 65536. The SIMD bitmap path
+                 (increment_counters_from_bitmap*) increments these counters
+                 with signed saturation and so caps at 32767; matching that
+                 here keeps every counter in [0, 32767], where the two paths
+                 agree and neither can wrap a high-overlap target's count back
+                 to ~0 and silently drop it from the candidate set (the cap is
+                 far above any realistic minwordmatches). */
+              count_t & counter = searchinfo->kmers[list[j]];
+              if (counter < INT16_MAX) { ++counter; }
             }
         }
     }


### PR DESCRIPTION
The per-target shared-k-mer counter (count_t, an unsigned short) was incremented with a plain ++ on the sparse-list path in search_topscores (searchcore.cc). A query that shares more than 65535 distinct k-mers with one target wraps that counter back toward 0; the wrapped value can then fall below minwordmatches and the true best target is silently dropped from the candidate set (or mis-ranked in the minheap).

The SIMD bitmap path (increment_counters_from_bitmap*) already increments these counters with signed saturation and so caps at INT16_MAX (32767). Both paths update the same counter array, so leaving the scalar path to run past 32767 is also internally inconsistent: a value the scalar path pushes into 32768..65535 is negative when the SIMD path reinterprets the counter as signed, and a subsequent saturating increment there can drive it back through zero.

Saturate the scalar increment at INT16_MAX to match the SIMD path. This keeps every counter in [0, 32767], where the two paths agree and neither can wrap; the cap is far above any realistic minwordmatches, so a high-overlap target stays a top candidate. Values below the cap (all ordinary data) are unaffected.


Claude-Session: https://claude.ai/code/session_01H6v7rX4pGLAL5BT2EWWxMM