### PR TITLE
Fix/freebsd dev stdin db

### DIFF
--- a/src/fastx.cc
+++ b/src/fastx.cc
@@ -257,7 +257,14 @@ auto fastx_open(char const * filename) -> fastx_handle
       fatal("Unable to get status for input file (%s)", filename);
     }
 
-  input_handle->is_pipe = S_ISFIFO(fs.st_mode);
+  /* Treat anything that is not a regular file as a non-rewindable stream:
+     named pipes, sockets, and character devices (such as FreeBSD's
+     /dev/stdin and the /dev/fd/N entries used by shell process
+     substitution) cannot be seeked, sized, or reopened from the start.
+     The compression autodetection below consumes bytes and then closes
+     and reopens the file to rewind, which silently corrupts such streams,
+     so it must be skipped for them. */
+  input_handle->is_pipe = not S_ISREG(fs.st_mode);
 
   if (input_handle->is_pipe)
     {
@@ -289,11 +296,12 @@ auto fastx_open(char const * filename) -> fastx_handle
     }
   else if (input_handle->is_pipe)
     {
-      /* non-stdin pipe (e.g. bash process substitution, named FIFO):
-         the decompress flags were meant for stdin, not for arbitrary
-         pipes wired in by the shell. Assume plain; compressed inputs
-         should be passed as a regular file or pre-decompressed
-         upstream of the pipe. */
+      /* non-stdin, non-rewindable stream (e.g. bash process
+         substitution, a named FIFO, or a character device such as
+         /dev/stdin on FreeBSD): the decompress flags were meant for
+         stdin, not for arbitrary streams wired in by the shell. Assume
+         plain; compressed inputs should be passed as a regular file or
+         pre-decompressed upstream of the pipe. */
       input_handle->format = Format::plain;
     }
   else

--- a/src/udb.cc
+++ b/src/udb.cc
@@ -182,24 +182,33 @@ auto udb_detect_isudb(const char * filename) -> bool
   constexpr static uint32_t udb_file_signature {0x55444246}; // 'FBDU UDBF'
   constexpr static uint64_t expected_n_bytes {sizeof(uint32_t)};
 
-  xstat_t fs;
-
-  if (xstat(filename, & fs) != 0)
+  int const file_descriptor = xopen_read(filename);
+  if (file_descriptor < 0)
     {
+      fatal("Unable to open input file for reading (%s)", filename);
+    }
+
+  /* Only a regular file can be probed here and then reopened from the
+     start by the actual reader. A non-rewindable stream (a named pipe,
+     or a character device such as FreeBSD's /dev/stdin and the /dev/fd/N
+     entries created by shell process substitution) cannot be a UDB file,
+     and reading its magic number would consume bytes the subsequent
+     reader could not recover. Stat the open descriptor rather than the
+     path: on FreeBSD /dev/stdin is a character device that stat() of the
+     path does not report as a pipe. For such streams, bail out without
+     consuming any input. */
+
+  xstat_t fs;
+  if (xfstat(file_descriptor, & fs) != 0)
+    {
+      close(file_descriptor);
       fatal("Unable to get status for input file (%s)", filename);
     }
 
-  auto const is_pipe = S_ISFIFO(fs.st_mode);
-  if (is_pipe)
+  if (not S_ISREG(fs.st_mode))
     {
+      close(file_descriptor);
       return false;
-    }
-
-  int file_descriptor = 0;
-  file_descriptor = xopen_read(filename);
-  if (file_descriptor == 0)
-    {
-      fatal("Unable to open input file for reading (%s)", filename);
     }
 
   unsigned int magic = 0;


### PR DESCRIPTION
On FreeBSD, reading `--db` from `/dev/stdin` (e.g. a reference database piped
into uchime_ref) aborted with "Fatal error: File type not recognized."

Before loading the database, `udb_detect_isudb()` peeks at the 4-byte UDB magic
number, relying on the subsequent reader to reopen the file from the start. That
reopen-rewind only works for regular files, so the peek was skipped for pipes —
but the check used `stat()` on the *path*, which on FreeBSD sees `/dev/stdin` as
a character device, not a FIFO. The peek then consumed the first 4 bytes, and
the FASTA reader saw a truncated stream. On Linux these paths resolve to FIFOs,
so the bug was FreeBSD-only.

Fix: `fstat()` the open descriptor instead of `stat()`-ing the path, and treat
any non-regular file as non-UDB, returning without consuming input. A companion
change makes the FASTA/FASTQ reader treat any non-regular file (not just FIFOs)
as a non-rewindable stream.

Verified with the issue-506 tests in `frederic-mahe/vsearch-tests` on FreeBSD;
Linux/macOS unaffected.