### PR TITLE
Fix a data race in uchime_ref and remove a dead, racy scorematrix global

### DIFF
--- a/src/align_simd.cc
+++ b/src/align_simd.cc
@@ -116,9 +116,6 @@ namespace {
 */
 
 
-static std::array<std::array<int64_t, matrix_size>, matrix_size> scorematrix {{}};
-
-
 // anonymous namespace: limit visibility and usage to this translation unit
 namespace {
 
@@ -1354,7 +1351,6 @@ auto search16_init(CELL score_match,
               value = opt_mismatch;
             }
           (reinterpret_cast<CELL *>(s->matrix.data()))[(matrix_size * i) + j] = value;
-          scorematrix[i][j] = value;
         }
     }
 

--- a/src/chimera.cc
+++ b/src/chimera.cc
@@ -2094,6 +2094,12 @@ auto chimera_thread_core(struct chimera_info_s * ci,
 
       std::unique_lock<std::mutex> input_lock(mutex_input);
 
+      /* Query-file progress position. Read here, under input_lock, into a
+         worker-local: fasta_get_position() reads the shared query handle,
+         which another worker advances in fasta_next() under the same lock.
+         Reading it later under mutex_output (as before) raced that writer. */
+      uint64_t query_position = 0;
+
       if (opt_uchime_ref != nullptr)
         {
           if (fasta_next(query_fasta_h, (opt_notrunclabels == 0),
@@ -2110,6 +2116,7 @@ auto chimera_thread_core(struct chimera_info_s * ci,
               /* copy the data locally (query seq, head) */
               std::strcpy(ci->query_head.data(), fasta_get_header(query_fasta_h));
               std::strcpy(ci->query_seq.data(), fasta_get_sequence(query_fasta_h));
+              query_position = fasta_get_position(query_fasta_h);
             }
           else
             {
@@ -2271,7 +2278,7 @@ auto chimera_thread_core(struct chimera_info_s * ci,
 
       if (opt_uchime_ref != nullptr)
         {
-          progress = fasta_get_position(query_fasta_h);
+          progress = query_position;
         }
       else
         {


### PR DESCRIPTION
Two small, independent thread-safety fixes in the alignment/chimera code,
both surfaced by a ThreadSanitizer run of the test suite.

## 1. Data race on the query file position in `uchime_ref`

In `chimera_thread_core`, the `uchime_ref` path read the query-file progress
position with `fasta_get_position(query_fasta_h)` while holding `mutex_output`,
but another worker advances the *same* shared handle in `fasta_next()` — which
writes `file_position` via `fastx_file_fill_buffer()` — while holding
`mutex_input`. The two accesses to `file_position` were serialized by *different*
mutexes, so they raced.

Fix: capture the position into a worker-local immediately after `fasta_next()`,
**under `mutex_input`**, and assign the shared `progress` counter from that local
under `mutex_output` — matching how `search` and `sintax` already capture
progress inside the input lock. The reported progress value is unchanged.

## 2. Remove the unused file-scope `scorematrix` in `align_simd`

The file-static `scorematrix` array was written by `search16_init()` but never
read (the aligner uses the per-instance `s->matrix`). The write was dead, and
because `search16_init()` runs inside the worker threads on the chimera path,
multiple workers wrote the shared global concurrently — a race on a value nobody
consumes. Dropping the global and its lone write removes both the dead store and
the race, with no behavioral change.

## Testing

- Builds cleanly (`-O2`).
- A ThreadSanitizer build over repeated `uchime_ref` runs reports no races after
  the fixes; alignment output is unchanged.