### PR TITLE
ci: refresh build-and-test and build-all workflows

### DIFF
--- a/.github/workflows/build-all.yml
+++ b/.github/workflows/build-all.yml
@@ -3,6 +3,10 @@ name: Build release binaries for all platforms
 on:
   workflow_dispatch:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   ubuntu:
     runs-on: ubuntu-latest
@@ -38,7 +42,7 @@ jobs:
         mv bin/${{ matrix.target.bin }} bin/${{ matrix.target.out }}
 
     - name: Upload artifact
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v7
       with:
         name: ${{ matrix.target.out }}
         path: bin/${{ matrix.target.out }}
@@ -61,6 +65,18 @@ jobs:
 
     - name: Install dependencies
       run: |
+        # aws/tap and azure/bicep are pre-tapped on the GitHub macOS runner
+        # images and trigger Homebrew tap-trust warnings; we use nothing from
+        # them, so remove them before updating/installing. azure/bicep ships an
+        # installed formula (bicep): uninstall it first so the tap untaps
+        # cleanly without --force (which would itself print a warning). Each
+        # step is guarded so it stays quiet and non-fatal on a future image
+        # that no longer has these taps/formulae. We do NOT silence stderr of
+        # the actual operations: hiding it is what masked the earlier failure.
+        brew list bicep >/dev/null 2>&1 && brew uninstall bicep
+        for tap in aws/tap azure/bicep; do
+          brew tap | grep -qx "$tap" && brew untap "$tap"
+        done
         brew update
         brew install autoconf automake ghostscript groff
 
@@ -74,7 +90,7 @@ jobs:
         bin/${{ matrix.target.out }} -v
 
     - name: Upload artifact
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v7
       with:
         name: ${{ matrix.target.out }}
         path: bin/${{ matrix.target.out }}

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -6,9 +6,14 @@ on:
   pull_request:
     branches: [ "master", "dev" ]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   linux-x86_64:
     runs-on: ubuntu-latest
+    timeout-minutes: 20
 
     steps:
     - name: Checkout
@@ -37,6 +42,7 @@ jobs:
 
   cross-build:
     runs-on: ubuntu-latest
+    timeout-minutes: 20
 
     strategy:
       fail-fast: false
@@ -69,6 +75,7 @@ jobs:
 
   macos-arm64:
     runs-on: macos-latest
+    timeout-minutes: 20
 
     steps:
     - name: Checkout
@@ -76,6 +83,18 @@ jobs:
 
     - name: Install dependencies
       run: |
+        # aws/tap and azure/bicep are pre-tapped on the GitHub macOS runner
+        # images and trigger Homebrew tap-trust warnings; we use nothing from
+        # them, so remove them before updating/installing. azure/bicep ships an
+        # installed formula (bicep): uninstall it first so the tap untaps
+        # cleanly without --force (which would itself print a warning). Each
+        # step is guarded so it stays quiet and non-fatal on a future image
+        # that no longer has these taps/formulae. We do NOT silence stderr of
+        # the actual operations: hiding it is what masked the earlier failure.
+        brew list bicep >/dev/null 2>&1 && brew uninstall bicep
+        for tap in aws/tap azure/bicep; do
+          brew tap | grep -qx "$tap" && brew untap "$tap"
+        done
         brew update
         brew install autoconf automake ghostscript groff
 
@@ -97,6 +116,7 @@ jobs:
 
   macos-x86_64:
     runs-on: macos-15-intel
+    timeout-minutes: 20
 
     steps:
     - name: Checkout
@@ -104,6 +124,18 @@ jobs:
 
     - name: Install dependencies
       run: |
+        # aws/tap and azure/bicep are pre-tapped on the GitHub macOS runner
+        # images and trigger Homebrew tap-trust warnings; we use nothing from
+        # them, so remove them before updating/installing. azure/bicep ships an
+        # installed formula (bicep): uninstall it first so the tap untaps
+        # cleanly without --force (which would itself print a warning). Each
+        # step is guarded so it stays quiet and non-fatal on a future image
+        # that no longer has these taps/formulae. We do NOT silence stderr of
+        # the actual operations: hiding it is what masked the earlier failure.
+        brew list bicep >/dev/null 2>&1 && brew uninstall bicep
+        for tap in aws/tap azure/bicep; do
+          brew tap | grep -qx "$tap" && brew untap "$tap"
+        done
         brew update
         brew install autoconf automake ghostscript groff
 
@@ -125,6 +157,7 @@ jobs:
 
   freebsd-x86_64:
     runs-on: ubuntu-latest
+    timeout-minutes: 20
 
     steps:
     - name: Checkout


### PR DESCRIPTION
# ci: refresh build-and-test and build-all workflows

## Summary

Updates the two CI workflows (`build-and-test.yml`, `build-all.yml`) with
reliability and hygiene improvements accumulated during fork development.
No source or build-system changes — this is CI only.

## Changes

### Both workflows

- Add a `concurrency` group with `cancel-in-progress: true`, so a new push/PR
  run automatically cancels the superseded run on the same ref instead of
  queuing behind it.
- Bump pinned actions to current major versions (`actions/checkout@v6`,
  `actions/upload-artifact@v7`), off the deprecated Node.js 20 runtime.
- macOS jobs: the GitHub runner images ship pre-tapped `aws/tap` and
  `azure/bicep`, which emit Homebrew "tap-trust" warnings on every run. We use
  neither, so they're removed before `brew update`/`install`. `azure/bicep`
  carries an installed `bicep` formula, so it's uninstalled first and the tap
  then removed without `--force` (which would print its own warning). Each step
  is guarded to stay quiet and non-fatal on a future image that no longer ships
  these taps.

### `build-and-test.yml`

- Add `timeout-minutes: 20` to every job so a hung job (notably the FreeBSD VM)
  fails fast instead of burning the full 6-hour default.
- Run the full push/PR matrix: native `linux-x86_64`, a cross-build matrix
  (Windows, aarch64, mips64el, ppc64le, riscv64), macOS arm64 + Intel, and
  FreeBSD.
- FreeBSD job: stream the ~7,700-test suite into a log file inside the VM under
  an unprivileged user, then surface a bounded summary (FAIL lines + log tail).
  Streaming that volume of output over the vmactions SSH channel wedged the
  guest at a random point a few minutes in; logging to a file and printing a
  summary fixes the stall. The unprivileged user is required because root
  bypasses POSIX permission checks, which the suite's "file not
  readable/writable" tests depend on.

### `build-all.yml`

- `concurrency` + updated actions as above; macOS matrix builds release
  binaries for arm64 and Intel with the same tap cleanup.

## Notes

These were validated on the fork's CI (Linux, all cross-builds, macOS
arm64/Intel, FreeBSD all green; macOS install step now annotation-free).