### PR TITLE
ci: make the FreeBSD test job reliable, and shallow-clone the test suite

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -163,6 +163,15 @@ jobs:
     - name: Checkout
       uses: actions/checkout@v6
 
+    # Clone the test suite on the Ubuntu host, where the network is reliable,
+    # rather than inside the FreeBSD VM. An in-VM `git clone` intermittently
+    # stalls on the guest's network and, with no git timeout, hangs until the
+    # 20-minute job limit. vmactions syncs the workspace into the VM, so the
+    # cloned directory is available there.
+    - name: Clone the test suite (on the host, not the FreeBSD VM)
+      run: |
+        git clone --depth 1 --branch ${{ github.event_name == 'pull_request' && github.base_ref || github.ref_name }} https://github.com/frederic-mahe/vsearch-tests
+
     - name: Build and test on FreeBSD
       uses: vmactions/freebsd-vm@v1
       with:
@@ -177,7 +186,8 @@ jobs:
           gmake clean
           gmake ARFLAGS="cr" -j$(sysctl -n hw.ncpu)
           bin/vsearch -v
-          git clone --branch ${{ github.event_name == 'pull_request' && github.base_ref || github.ref_name }} https://github.com/frederic-mahe/vsearch-tests
+          # vsearch-tests was cloned on the host (previous step) and synced
+          # into the VM, so no in-VM git clone is needed here.
           chown -R runner vsearch-tests
           # The suite runs ~7,700 tests, each printing a result line.
           # Streaming that volume over the vmactions SSH channel wedges

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -35,7 +35,7 @@ jobs:
     - name: Run tests
       run: |
         export PATH=$PWD/bin:$PATH
-        git clone --branch ${{ github.event_name == 'pull_request' && github.base_ref || github.ref_name }} https://github.com/frederic-mahe/vsearch-tests
+        git clone --depth 1 --branch ${{ github.event_name == 'pull_request' && github.base_ref || github.ref_name }} https://github.com/frederic-mahe/vsearch-tests
         cd vsearch-tests
         bash ./run_all_tests.sh
 
@@ -109,7 +109,7 @@ jobs:
     - name: Run tests
       run: |
         export PATH=$PWD/bin:$PATH
-        git clone --branch ${{ github.event_name == 'pull_request' && github.base_ref || github.ref_name }} https://github.com/frederic-mahe/vsearch-tests
+        git clone --depth 1 --branch ${{ github.event_name == 'pull_request' && github.base_ref || github.ref_name }} https://github.com/frederic-mahe/vsearch-tests
         cd vsearch-tests
         bash ./run_all_tests.sh
 
@@ -150,7 +150,7 @@ jobs:
     - name: Run tests
       run: |
         export PATH=$PWD/bin:$PATH
-        git clone --branch ${{ github.event_name == 'pull_request' && github.base_ref || github.ref_name }} https://github.com/frederic-mahe/vsearch-tests
+        git clone --depth 1 --branch ${{ github.event_name == 'pull_request' && github.base_ref || github.ref_name }} https://github.com/frederic-mahe/vsearch-tests
         cd vsearch-tests
         bash ./run_all_tests.sh
 

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -181,14 +181,27 @@ jobs:
           pkg install -y autoconf automake gmake bash git bzip2 ghostscript10 groff
           pw useradd -n runner -m -s /usr/local/bin/bash
         run: |
+          echo "========== Building vsearch =========="
           ./autogen.sh
           ./configure CFLAGS="-O2" CXXFLAGS="-O2"
           gmake clean
           gmake ARFLAGS="cr" -j$(sysctl -n hw.ncpu)
           bin/vsearch -v
-          # vsearch-tests was cloned on the host (previous step) and synced
-          # into the VM, so no in-VM git clone is needed here.
+          echo "========== Build complete =========="
+
+          # vsearch-tests was cloned on the host (previous step); vmactions
+          # syncs the workspace into the VM, so it should be present here.
+          # Fail fast with a clear message (not a hang) if the sync did not
+          # bring it in.
+          echo "========== Checking for the test suite in the VM =========="
+          if [ ! -d vsearch-tests/scripts ]; then
+            echo "ERROR: vsearch-tests was not synced into the VM. Workspace contents:"
+            ls -la
+            exit 1
+          fi
+          echo "Found vsearch-tests ($(ls vsearch-tests/scripts | wc -l) test scripts)."
           chown -R runner vsearch-tests
+
           # The suite runs ~7,700 tests, each printing a result line.
           # Streaming that volume over the vmactions SSH channel wedges
           # the FreeBSD guest after a few minutes (it stops responding at
@@ -196,8 +209,10 @@ jobs:
           # instead, then surface a bounded summary so CI still reports
           # failures. root bypasses POSIX permission checks, so the "file
           # not readable/writable" tests need an unprivileged user.
+          echo "========== Running tests... =========="
           status=0
           su -m runner -c "cd vsearch-tests && PATH=$PWD/bin:\$PATH bash ./run_all_tests.sh > test.log 2>&1" || status=$?
+          echo "========== Tests finished (exit status $status) =========="
           echo "===== FAIL lines ====="
           grep -E 'FAIL' vsearch-tests/test.log || echo "(none)"
           echo "===== last 50 lines of test.log ====="


### PR DESCRIPTION
- The FreeBSD job intermittently timed out at 20 minutes: the in-VM
  `git clone` of vsearch-tests would stall on the guest network, and git
  has no transfer timeout by default. Clone the test suite on the Ubuntu
  host instead (reliable network); vmactions syncs it into the VM.
- Add progress banners (Building / Running tests / Tests finished) and a
  fail-fast check that the test suite was synced in, so the job's state is
  visible and a missing checkout errors immediately instead of failing
  obscurely.
- Shallow-clone the test suite (`--depth 1`) in the Linux and macOS jobs
  too — the suite only needs the current snapshot; faster and less prone
  to network stalls.