### PR TITLE
Fix integer overflow when sizing the fastq_eestats2 count table

### DIFF
--- a/src/eestats.cc
+++ b/src/eestats.cc
@@ -459,7 +459,7 @@ auto fastq_eestats2(struct Parameters const & parameters) -> void
 
           if (new_len_steps > len_steps)
             {
-              count_table.resize(static_cast<size_t>(new_len_steps * opt_ee_cutoffs_count));
+              count_table.resize(static_cast<size_t>(new_len_steps) * static_cast<size_t>(opt_ee_cutoffs_count));
               len_steps = new_len_steps;
             }
         }
@@ -489,7 +489,7 @@ auto fastq_eestats2(struct Parameters const & parameters) -> void
                     {
                       if (ee <= opt_ee_cutoffs_values[y])
                         {
-                          ++count_table[static_cast<size_t>((x * opt_ee_cutoffs_count) + y)];
+                          ++count_table[((static_cast<size_t>(x) * static_cast<size_t>(opt_ee_cutoffs_count)) + static_cast<size_t>(y))];
                         }
                     }
                 }
@@ -540,8 +540,8 @@ auto fastq_eestats2(struct Parameters const & parameters) -> void
         {
           std::fprintf(fp_output,
                   "   %8" PRIu64 "(%5.1f%%)",
-                  count_table[static_cast<size_t>((x * opt_ee_cutoffs_count) + y)],
-                  100.0 * static_cast<double>(count_table[static_cast<size_t>((x * opt_ee_cutoffs_count) + y)]) / static_cast<double>(seq_count));
+                  count_table[((static_cast<size_t>(x) * static_cast<size_t>(opt_ee_cutoffs_count)) + static_cast<size_t>(y))],
+                  100.0 * static_cast<double>(count_table[((static_cast<size_t>(x) * static_cast<size_t>(opt_ee_cutoffs_count)) + static_cast<size_t>(y))]) / static_cast<double>(seq_count));
         }
       std::fprintf(fp_output, "\n");
     }
@@ -580,8 +580,8 @@ auto fastq_eestats2(struct Parameters const & parameters) -> void
             {
               std::fprintf(fp_log,
                       "   %8" PRIu64 "(%5.1f%%)",
-                      count_table[static_cast<size_t>((x * opt_ee_cutoffs_count) + y)],
-                      100.0 * static_cast<double>(count_table[static_cast<size_t>((x * opt_ee_cutoffs_count) + y)]) / static_cast<double>(seq_count));
+                      count_table[((static_cast<size_t>(x) * static_cast<size_t>(opt_ee_cutoffs_count)) + static_cast<size_t>(y))],
+                      100.0 * static_cast<double>(count_table[((static_cast<size_t>(x) * static_cast<size_t>(opt_ee_cutoffs_count)) + static_cast<size_t>(y))]) / static_cast<double>(seq_count));
             }
           std::fprintf(fp_log, "\n");
         }


### PR DESCRIPTION
## Summary

In `--fastq_eestats2`, the per-(length-step, EE-cutoff) count table is sized with
`new_len_steps * opt_ee_cutoffs_count` and indexed with
`(x * opt_ee_cutoffs_count) + y`, both computed in `int` before being widened to
`size_t`. With a large `--length_cutoffs` range combined with many `--ee_cutoffs`
values the `int` product can overflow: the `resize()` then wraps to a small (or
huge) value and the indices wrap independently, allowing out-of-bounds writes
into the vector.

## Fix

Widen each operand to `size_t` before the multiplication, so the table is both
sized and addressed in 64-bit arithmetic. Output is unchanged for all realistic
inputs; only the overflow edge is affected.

## Testing

Default and `-Wconversion`/`-Wsign-conversion` debug builds are clean;
`--fastq_eestats2` with `--length_cutoffs`/`--ee_cutoffs` produces correct
output.