### PR TITLE
Prevent 32-bit integer overflow on very long sequences/headers

### DIFF
--- a/man/commands/fragments/option_maxseqlength.md
+++ b/man/commands/fragments/option_maxseqlength.md
@@ -1,3 +1,4 @@
 `--maxseqlength` *positive integer*
 : Discard sequences longer than *positive integer* (50,000 nucleotides
-  by default). The value must not exceed 4,294,967,295 (`UINT32_MAX`).
+  by default). The value must not exceed 2,147,481,646 (`INT_MAX` minus
+  2,001).

--- a/man/vsearch.1
+++ b/man/vsearch.1
@@ -383,7 +383,8 @@ information to the log file.
 .TP
 .BI \-\-maxseqlength\~ "positive integer"
 All \fBvsearch\fR operations discard sequences longer than
-\fIinteger\fR (50,000 nucleotides by default).
+\fIinteger\fR (50,000 nucleotides by default). The value must not
+exceed 2,147,481,646 (\fIINT_MAX\fR minus 2,001).
 .TAG minseqlength
 .TP
 .BI \-\-minseqlength\~ "positive integer"

--- a/src/chimera.cc
+++ b/src/chimera.cc
@@ -252,7 +252,7 @@ auto realloc_arrays(struct chimera_info_s * chimera_info) -> void
   /* realloc arrays based on query length */
 
   const int maxqlen = std::max(chimera_info->query_len, 1);
-  auto const max_2x2_size = static_cast<size_t>(maxcandidates * maxqlen);
+  auto const max_2x2_size = static_cast<size_t>(maxcandidates) * static_cast<size_t>(maxqlen);
 
   if (maxqlen > chimera_info->query_alloc)
     {
@@ -269,7 +269,7 @@ auto realloc_arrays(struct chimera_info_s * chimera_info) -> void
       chimera_info->scan_p.resize(static_cast<size_t>(maxqlen) + 1);
       chimera_info->scan_q.resize(static_cast<size_t>(maxqlen) + 1);
 
-      const int maxalnlen = maxqlen + (2 * static_cast<int>(db_getlongestsequence()));
+      const int64_t maxalnlen = static_cast<int64_t>(maxqlen) + (2 * static_cast<int64_t>(db_getlongestsequence()));
       chimera_info->paln.resize(maxparents);
       for (auto & a_parent_alignment : chimera_info->paln) {
         a_parent_alignment.resize(static_cast<size_t>(maxalnlen) + 1);
@@ -616,16 +616,16 @@ auto find_best_parents(struct chimera_info_s * ci) -> int
               int sum = 0;
               for (int qpos = 0; qpos < ci->query_len; ++qpos)
                 {
-                  int const z = (i * ci->query_len) + qpos;
-                  sum += ci->match[static_cast<size_t>(z)];
+                  size_t const z = (static_cast<size_t>(i) * static_cast<size_t>(ci->query_len)) + static_cast<size_t>(qpos);
+                  sum += ci->match[z];
                   if (qpos >= window)
                     {
-                      sum -= ci->match[static_cast<size_t>(z - window)];
+                      sum -= ci->match[z - static_cast<size_t>(window)];
                     }
                   if (qpos >= window - 1)
                     {
-                      ci->smooth[static_cast<size_t>(z)] = sum;
-                      ci->maxsmooth[static_cast<size_t>(qpos)] = std::max(ci->smooth[static_cast<size_t>(z)], ci->maxsmooth[static_cast<size_t>(qpos)]);
+                      ci->smooth[z] = sum;
+                      ci->maxsmooth[static_cast<size_t>(qpos)] = std::max(ci->smooth[z], ci->maxsmooth[static_cast<size_t>(qpos)]);
                     }
                 }
             }
@@ -644,8 +644,8 @@ auto find_best_parents(struct chimera_info_s * ci) -> int
                 {
                   if (not cand_selected[static_cast<size_t>(i)])
                     {
-                      int const z = (i * ci->query_len) + qpos;
-                      if (ci->smooth[static_cast<size_t>(z)] == ci->maxsmooth[static_cast<size_t>(qpos)])
+                      size_t const z = (static_cast<size_t>(i) * static_cast<size_t>(ci->query_len)) + static_cast<size_t>(qpos);
+                      if (ci->smooth[z] == ci->maxsmooth[static_cast<size_t>(qpos)])
                         {
                           ++wins[static_cast<size_t>(i)];
                         }

--- a/src/cli.cc
+++ b/src/cli.cc
@@ -4438,9 +4438,16 @@ auto args_init(int argc, char ** argv, struct Parameters & parameters) -> void
       fatal("The argument to --maxseqlength must be a positive integer");
     }
 
-  if (opt_maxseqlength > UINT32_MAX)
+  // The sequence length is narrowed to int in the search/cluster/chimera
+  // engine (searchinfo_s::qseqlen, sized as qseqlen + 2001), so a longer
+  // sequence would wrap negative and overflow the per-query buffer. Cap the
+  // option at INT_MAX - 2001 so that cannot happen; this mirrors the header
+  // length limit enforced in fastx_filter_header.
+  static constexpr int64_t maxseqlength_limit =
+    std::numeric_limits<int>::max() - 2001;
+  if (opt_maxseqlength > maxseqlength_limit)
     {
-      fatal("The argument to --maxseqlength cannot exceed 4294967295");
+      fatal("The argument to --maxseqlength cannot exceed 2147481646 (INT_MAX - 2001)");
     }
 
   if (parameters.opt_chimeras_denovo != nullptr)

--- a/src/cli.cc
+++ b/src/cli.cc
@@ -4439,15 +4439,19 @@ auto args_init(int argc, char ** argv, struct Parameters & parameters) -> void
     }
 
   // The sequence length is narrowed to int in the search/cluster/chimera
-  // engine (searchinfo_s::qseqlen, sized as qseqlen + 2001), so a longer
-  // sequence would wrap negative and overflow the per-query buffer. Cap the
-  // option at INT_MAX - 2001 so that cannot happen; this mirrors the header
-  // length limit enforced in fastx_filter_header.
-  static constexpr int64_t maxseqlength_limit =
-    std::numeric_limits<int>::max() - 2001;
+  // engine (searchinfo_s::qseqlen, sized as qseqlen + buffer_headroom), so a
+  // longer sequence would wrap negative and overflow the per-query buffer. Cap
+  // the option at INT_MAX - buffer_headroom so that cannot happen; this mirrors
+  // the header length limit enforced in fastx_filter_header.
+  static constexpr int maxseqlength_limit =
+    std::numeric_limits<int>::max() - buffer_headroom;
   if (opt_maxseqlength > maxseqlength_limit)
     {
-      fatal("The argument to --maxseqlength cannot exceed 2147481646 (INT_MAX - 2001)");
+      std::array<char, 128> message {{}};
+      std::snprintf(message.data(), message.size(),
+                    "The argument to --maxseqlength cannot exceed %d (INT_MAX - %d)",
+                    maxseqlength_limit, buffer_headroom);
+      fatal(message.data());
     }
 
   if (parameters.opt_chimeras_denovo != nullptr)

--- a/src/db.h
+++ b/src/db.h
@@ -70,7 +70,7 @@ struct seqinfo_s
   std::size_t seq_p {};
   std::size_t qual_p {};
   // headerlen and seqlen are intentionally kept 32-bit: --maxseqlength is
-  // capped at INT_MAX - 2001 (see cli.cc), well under the 32-bit field
+  // capped at INT_MAX - buffer_headroom (see cli.cc), well under the 32-bit field
   // maximum, so no accepted record can overflow them, and the two fields share
   // a single 8-byte slot here. Widening either to 64-bit grows seqinfo_s from
   // 40 to 48 bytes — +8 bytes per sequence in the seqindex array (alignment

--- a/src/db.h
+++ b/src/db.h
@@ -70,13 +70,14 @@ struct seqinfo_s
   std::size_t seq_p {};
   std::size_t qual_p {};
   // headerlen and seqlen are intentionally kept 32-bit: --maxseqlength is
-  // capped at UINT32_MAX (see cli.cc), so no accepted record can overflow
-  // them, and the two fields share a single 8-byte slot here. Widening either
-  // to 64-bit grows seqinfo_s from 40 to 48 bytes — +8 bytes per sequence in
-  // the seqindex array (alignment padding makes widening just one cost the
-  // same as widening both). If the --maxseqlength cap is ever raised above
-  // UINT32_MAX, widen both to uint64_t (and drop the narrowing casts in
-  // db_add()); until then the cap is the guard for the N1(c) storage path.
+  // capped at INT_MAX - 2001 (see cli.cc), well under the 32-bit field
+  // maximum, so no accepted record can overflow them, and the two fields share
+  // a single 8-byte slot here. Widening either to 64-bit grows seqinfo_s from
+  // 40 to 48 bytes — +8 bytes per sequence in the seqindex array (alignment
+  // padding makes widening just one cost the same as widening both). If the
+  // --maxseqlength cap is ever raised above UINT32_MAX, widen both to uint64_t
+  // (and drop the narrowing casts in db_add()); until then the cap is the guard
+  // for the N1(c) storage path.
   unsigned int headerlen {};
   unsigned int seqlen {};
   uint64_t size {};  // abundance; 64-bit so a per-sequence ;size= above UINT_MAX

--- a/src/fasta.cc
+++ b/src/fasta.cc
@@ -359,6 +359,7 @@ auto fasta_next(fastx_handle input_handle,
 
   fastx_filter_header(input_handle, truncateatspace);
   fasta_filter_sequence(input_handle, char_mapping);
+  fastx_filter_sequence_length(input_handle);
 
   return true;
 }

--- a/src/fastq.cc
+++ b/src/fastq.cc
@@ -598,6 +598,7 @@ auto fastq_next(fastx_handle input_handle,
     }
 
   fastx_filter_header(input_handle, truncateatspace);
+  fastx_filter_sequence_length(input_handle);
 
   input_handle->seqno++;
 

--- a/src/fastx.cc
+++ b/src/fastx.cc
@@ -753,6 +753,38 @@ auto fastx_set_deferred_error(fastx_handle input_handle, char const * message) -
 }
 
 
+auto fastx_query_length_ok(fastx_handle input_handle) -> bool
+{
+  /* The search engine stores a query sequence length in an int field
+     (searchinfo_s::qseqlen, sized as qseqlen + buffer_headroom). Database
+     sequences are length-filtered by --maxseqlength in db_read, but query
+     sequences are not, so a query longer than that int field can hold would be
+     narrowed to a negative length and overflow the per-query buffer. Reject it
+     here. Mirrors fastx_filter_header: on a worker thread the error is recorded
+     and reported from the main thread (never fatal()ed off-main), otherwise
+     fatal(). Returns true if the current query may be processed. */
+  static constexpr auto limit =
+    static_cast<uint64_t>(std::numeric_limits<int>::max() - buffer_headroom);
+  auto const length = fastx_get_sequence_length(input_handle);
+  if (length <= limit)
+    {
+      return true;
+    }
+  std::array<char, 256> message {{}};
+  std::snprintf(message.data(), message.size(),
+                "FASTA/FASTQ query sequence too long (%" PRIu64 " nt).\n"
+                "Query sequences longer than %" PRIu64 " nt are not supported.",
+                length, limit);
+  if (input_handle->defer_errors)
+    {
+      fastx_set_deferred_error(input_handle, message.data());
+      return false;
+    }
+  fatal(message.data());
+  return false;
+}
+
+
 auto fastx_get_position(struct fastx_s const * input_handle) -> uint64_t
 {
   if (input_handle->is_fastq)

--- a/src/fastx.cc
+++ b/src/fastx.cc
@@ -753,35 +753,36 @@ auto fastx_set_deferred_error(fastx_handle input_handle, char const * message) -
 }
 
 
-auto fastx_query_length_ok(fastx_handle input_handle) -> bool
+auto fastx_filter_sequence_length(fastx_handle input_handle) -> void
 {
-  /* The search engine stores a query sequence length in an int field
-     (searchinfo_s::qseqlen, sized as qseqlen + buffer_headroom). Database
-     sequences are length-filtered by --maxseqlength in db_read, but query
-     sequences are not, so a query longer than that int field can hold would be
-     narrowed to a negative length and overflow the per-query buffer. Reject it
-     here. Mirrors fastx_filter_header: on a worker thread the error is recorded
-     and reported from the main thread (never fatal()ed off-main), otherwise
-     fatal(). Returns true if the current query may be processed. */
-  static constexpr auto limit =
+  /* Reject a sequence too long for the int sequence-length bookkeeping used
+     downstream (e.g. searchinfo_s::qseqlen, sized as qseqlen + buffer_headroom;
+     the chimera query buffers; cut's rc_buffer). Such a sequence would be
+     narrowed to a negative int and overflow the per-record buffer. Database
+     sequences over --maxseqlength are discarded by db_read, but many commands
+     read records directly via fasta_next/fastx_next with no length filter, so
+     guard it here, at the single point all FASTA/FASTQ (and DB) reads pass
+     through -- symmetric with the header guard in fastx_filter_header. Mirrors
+     its deferred/fatal handling: on a worker thread the error is recorded and
+     reported from the main thread, never fatal()ed here. */
+  static constexpr auto max_sequence_length =
     static_cast<uint64_t>(std::numeric_limits<int>::max() - buffer_headroom);
-  auto const length = fastx_get_sequence_length(input_handle);
-  if (length <= limit)
+  auto const length = input_handle->sequence_buffer.length;
+  if (length <= max_sequence_length)
     {
-      return true;
+      return;
     }
   std::array<char, 256> message {{}};
   std::snprintf(message.data(), message.size(),
-                "FASTA/FASTQ query sequence too long (%" PRIu64 " nt).\n"
-                "Query sequences longer than %" PRIu64 " nt are not supported.",
-                length, limit);
+                "FASTA/FASTQ sequence too long (%" PRIu64 " nt) on line %"
+                PRIu64 ".\nSequences longer than %" PRIu64 " nt are not supported.",
+                length, input_handle->lineno_start, max_sequence_length);
   if (input_handle->defer_errors)
     {
       fastx_set_deferred_error(input_handle, message.data());
-      return false;
+      return;
     }
   fatal(message.data());
-  return false;
 }
 
 

--- a/src/fastx.cc
+++ b/src/fastx.cc
@@ -192,15 +192,15 @@ auto fastx_filter_header(fastx_handle input_handle, bool truncateatspace) -> voi
 
   /* Reject a header too long for the int header-length bookkeeping used
      downstream (searchinfo_s::query_head_len / query_head_alloc, where the
-     allocation is query_head_len + 2001). Such a header would be narrowed to a
-     negative int and overflow the per-query header buffer. The sequence length
-     is bounded by --maxseqlength, but the header length is not, so guard it
-     here, at the single point all FASTA/FASTQ (and DB) reads pass through.
-     Mirrors the deferred/fatal handling of the illegal-character check below:
-     on a worker thread the error is recorded and reported from the main
+     allocation is query_head_len + buffer_headroom). Such a header would be
+     narrowed to a negative int and overflow the per-query header buffer. The
+     sequence length is bounded by --maxseqlength, but the header length is not,
+     so guard it here, at the single point all FASTA/FASTQ (and DB) reads pass
+     through. Mirrors the deferred/fatal handling of the illegal-character check
+     below: on a worker thread the error is recorded and reported from the main
      thread, never fatal()ed here. */
   static constexpr auto max_header_length =
-    static_cast<std::size_t>(std::numeric_limits<int>::max()) - 2001;
+    static_cast<std::size_t>(std::numeric_limits<int>::max() - buffer_headroom);
   if (count > max_header_length) {
     std::array<char, 256> message {{}};
     std::snprintf(message.data(), message.size(),

--- a/src/fastx.h
+++ b/src/fastx.h
@@ -158,12 +158,12 @@ auto fastx_get_sequence(fastx_handle input_handle) -> char const *;
 auto fastx_get_header_length(fastx_handle input_handle) -> uint64_t;
 auto fastx_get_sequence_length(fastx_handle input_handle) -> uint64_t;
 
-// Reject a query sequence too long for the int length fields in the search
-// engine (called from the query read loops; database sequences are filtered by
-// --maxseqlength in db_read instead). Returns true if the current record may be
-// processed; on a worker thread an over-long query records a deferred error
-// (reported from the main thread), otherwise it is fatal.
-auto fastx_query_length_ok(fastx_handle input_handle) -> bool;
+// Reject a sequence too long for the int length bookkeeping used downstream.
+// Called from fasta_next/fastx_next so every read is bounded at one choke
+// point, symmetric with fastx_filter_header. On a worker thread an over-long
+// sequence records a deferred error (reported from the main thread), otherwise
+// it is fatal.
+auto fastx_filter_sequence_length(fastx_handle input_handle) -> void;
 
 auto fastx_get_quality(fastx_handle input_handle) -> char const *;
 auto fastx_get_abundance(struct fastx_s const * input_handle) -> int64_t;

--- a/src/fastx.h
+++ b/src/fastx.h
@@ -158,6 +158,13 @@ auto fastx_get_sequence(fastx_handle input_handle) -> char const *;
 auto fastx_get_header_length(fastx_handle input_handle) -> uint64_t;
 auto fastx_get_sequence_length(fastx_handle input_handle) -> uint64_t;
 
+// Reject a query sequence too long for the int length fields in the search
+// engine (called from the query read loops; database sequences are filtered by
+// --maxseqlength in db_read instead). Returns true if the current record may be
+// processed; on a worker thread an over-long query records a deferred error
+// (reported from the main thread), otherwise it is fatal.
+auto fastx_query_length_ok(fastx_handle input_handle) -> bool;
+
 auto fastx_get_quality(fastx_handle input_handle) -> char const *;
 auto fastx_get_abundance(struct fastx_s const * input_handle) -> int64_t;
 

--- a/src/kmerhash.cc
+++ b/src/kmerhash.cc
@@ -108,9 +108,10 @@ auto kh_insert_kmers(struct kh_handle_s & kmer_hash, int const k_offset, char co
 
   /* reallocate hash table if necessary */
 
-  if (kmer_hash.alloc < 2 * len)
+  int64_t const needed = 2 * static_cast<int64_t>(len);
+  if (kmer_hash.alloc < needed)
     {
-      while (kmer_hash.alloc < 2 * len)
+      while (kmer_hash.alloc < needed)
         {
           kmer_hash.alloc *= 2;
         }
@@ -118,7 +119,7 @@ auto kh_insert_kmers(struct kh_handle_s & kmer_hash, int const k_offset, char co
     }
 
   kmer_hash.size = 1;
-  while (kmer_hash.size < 2 * len)
+  while (kmer_hash.size < needed)
     {
       kmer_hash.size *= 2;
     }

--- a/src/msa.cc
+++ b/src/msa.cc
@@ -186,8 +186,15 @@ auto find_max_insertions_per_position(int const target_count,
 }
 
 
-auto find_total_alignment_length(std::vector<int> const & max_insertions) -> int {
-  auto const centroid_len = static_cast<int>(max_insertions.size() - 1);
+auto find_total_alignment_length(std::vector<int> const & max_insertions) -> int64_t {
+  /* Sum in 64-bit: the total alignment length is centroid length plus the max
+     insertions at every position, which can exceed INT_MAX for a large cluster
+     even though each individual sequence is bounded. A 32-bit accumulator here
+     wraps to a wrong (often negative) length that then under-sizes the profile
+     and alignment buffers while the alignment walk uses the true extent -- a
+     heap overflow. With a 64-bit result the buffers are sized correctly; a true
+     length beyond int capacity fails the allocation cleanly before any walk. */
+  auto const centroid_len = static_cast<int64_t>(max_insertions.size() - 1);
   return std::accumulate(max_insertions.begin(), max_insertions.end(), centroid_len);
 }
 

--- a/src/msa.cc
+++ b/src/msa.cc
@@ -97,7 +97,7 @@ auto update_profile(char const nucleotide,
   static constexpr auto U_counter = 3;  // note: T converted to U?
   static constexpr auto N_counter = 4;
   static constexpr auto gap_counter = 5;
-  auto const offset = static_cast<std::vector<prof_type>::size_type>(profsize * position_in_alignment);
+  auto const offset = static_cast<std::vector<prof_type>::size_type>(profsize) * static_cast<std::vector<prof_type>::size_type>(position_in_alignment);
 
   // refactoring: eliminate unused cases? No, T and U are merged, same as IUPAC and N
   switch (std::toupper(nucleotide))
@@ -439,7 +439,7 @@ auto compute_and_print_consensus(std::vector<int> const &max_insertions,
       prof_type best_count = 0;
       for (auto nucleotide = 0U; nucleotide < 4; ++nucleotide)
         {
-          auto const count = profile[static_cast<std::vector<prof_type>::size_type>(profsize * i) + nucleotide];
+          auto const count = profile[(static_cast<std::vector<prof_type>::size_type>(profsize) * static_cast<std::vector<prof_type>::size_type>(i)) + nucleotide];
           if (count > best_count)
             {
               best_count = count;
@@ -448,7 +448,7 @@ auto compute_and_print_consensus(std::vector<int> const &max_insertions,
         }
 
       /* if no A, C, G, or T, check if there are any N's */
-      auto const N_count = profile[static_cast<std::vector<prof_type>::size_type>((profsize * i) + 4)];
+      auto const N_count = profile[(static_cast<std::vector<prof_type>::size_type>(profsize) * static_cast<std::vector<prof_type>::size_type>(i)) + 4U];
       if ((best_count == 0) and (N_count > 0))
         {
           best_count = N_count;
@@ -456,7 +456,7 @@ auto compute_and_print_consensus(std::vector<int> const &max_insertions,
         }
 
       /* compare to the number of gap symbols */
-      auto const gap_count = profile[static_cast<std::vector<prof_type>::size_type>((profsize * i) + 5)];
+      auto const gap_count = profile[(static_cast<std::vector<prof_type>::size_type>(profsize) * static_cast<std::vector<prof_type>::size_type>(i)) + 5U];
       if (best_count >= gap_count)
         {
           auto const index = static_cast<unsigned char>(best_sym);
@@ -533,7 +533,7 @@ auto print_alignment_profile(std::FILE *fp_profile, std::vector<char> &aln_v,
     static_cast<void>(std::fprintf(fp_profile, "%d\t%c", counter, nucleotide));
       // A, C, G and T, then gap '-', then N
       for (auto const symbol_index : symbol_indexes) {
-        static_cast<void>(std::fprintf(fp_profile, "\t%" PRId64, profile[static_cast<std::vector<prof_type>::size_type>((profsize * counter) + symbol_index)]));
+        static_cast<void>(std::fprintf(fp_profile, "\t%" PRId64, profile[(static_cast<std::vector<prof_type>::size_type>(profsize) * static_cast<std::vector<prof_type>::size_type>(counter)) + static_cast<std::vector<prof_type>::size_type>(symbol_index)]));
       }
       static_cast<void>(std::fprintf(fp_profile, "\n"));
       ++counter;

--- a/src/orient.cc
+++ b/src/orient.cc
@@ -218,6 +218,7 @@ auto orient(struct Parameters const & parameters) -> void
                     (opt_notrunclabels == 0),
                     chrmap_no_change_vector.data()))
     {
+      if (not fastx_query_length_ok(query_h)) { break; }
       char const * query_head = fastx_get_header(query_h);
       int const query_head_len = static_cast<int>(fastx_get_header_length(query_h));
       char const * qseq_fwd = fastx_get_sequence(query_h);

--- a/src/orient.cc
+++ b/src/orient.cc
@@ -218,7 +218,6 @@ auto orient(struct Parameters const & parameters) -> void
                     (opt_notrunclabels == 0),
                     chrmap_no_change_vector.data()))
     {
-      if (not fastx_query_length_ok(query_h)) { break; }
       char const * query_head = fastx_get_header(query_h);
       int const query_head_len = static_cast<int>(fastx_get_header_length(query_h));
       char const * qseq_fwd = fastx_get_sequence(query_h);

--- a/src/search.cc
+++ b/src/search.cc
@@ -418,7 +418,6 @@ auto search_thread_run(uint64_t t) -> void
                      (opt_notrunclabels == 0),
                      chrmap_no_change_vector.data()))
         {
-          if (not fastx_query_length_ok(query_fastx_h)) { break; }
           char const * qhead = fastx_get_header(query_fastx_h);
           int const query_head_len = static_cast<int>(fastx_get_header_length(query_fastx_h));
           char const * qseq = fastx_get_sequence(query_fastx_h);

--- a/src/search.cc
+++ b/src/search.cc
@@ -418,6 +418,7 @@ auto search_thread_run(uint64_t t) -> void
                      (opt_notrunclabels == 0),
                      chrmap_no_change_vector.data()))
         {
+          if (not fastx_query_length_ok(query_fastx_h)) { break; }
           char const * qhead = fastx_get_header(query_fastx_h);
           int const query_head_len = static_cast<int>(fastx_get_header_length(query_fastx_h));
           char const * qseq = fastx_get_sequence(query_fastx_h);

--- a/src/search.cc
+++ b/src/search.cc
@@ -381,14 +381,14 @@ static auto populate_si(struct searchinfo_s * si,
 
   if (si->query_head_len + 1 > si->query_head_alloc)
     {
-      si->query_head_alloc = si->query_head_len + 2001;
+      si->query_head_alloc = si->query_head_len + buffer_headroom;
       si->query_head = static_cast<char *>(
         xrealloc(si->query_head, static_cast<size_t>(si->query_head_alloc)));
     }
 
   if (si->qseqlen + 1 > si->seq_alloc)
     {
-      si->seq_alloc = si->qseqlen + 2001;
+      si->seq_alloc = si->qseqlen + buffer_headroom;
       si->qsequence = static_cast<char *>(
         xrealloc(si->qsequence, static_cast<size_t>(si->seq_alloc)));
     }

--- a/src/search_exact.cc
+++ b/src/search_exact.cc
@@ -428,6 +428,7 @@ auto search_exact_thread_run(uint64_t t) -> void
 
       if (fastx_next(query_fastx_h, (opt_notrunclabels == 0), chrmap_no_change_vector.data()))
         {
+          if (not fastx_query_length_ok(query_fastx_h)) { break; }
           char const * qhead = fastx_get_header(query_fastx_h);
           int const query_head_len = static_cast<int>(fastx_get_header_length(query_fastx_h));
           char const * qseq = fastx_get_sequence(query_fastx_h);

--- a/src/search_exact.cc
+++ b/src/search_exact.cc
@@ -449,14 +449,14 @@ auto search_exact_thread_run(uint64_t t) -> void
 
               if (si->query_head_len + 1 > si->query_head_alloc)
                 {
-                  si->query_head_alloc = si->query_head_len + 2001;
+                  si->query_head_alloc = si->query_head_len + buffer_headroom;
                   si->query_head = static_cast<char *>(
                     xrealloc(si->query_head, static_cast<size_t>(si->query_head_alloc)));
                 }
 
               if (si->qseqlen + 1 > si->seq_alloc)
                 {
-                  si->seq_alloc = si->qseqlen + 2001;
+                  si->seq_alloc = si->qseqlen + buffer_headroom;
                   si->qsequence = static_cast<char *>(
                     xrealloc(si->qsequence, static_cast<size_t>(si->seq_alloc)));
                 }

--- a/src/search_exact.cc
+++ b/src/search_exact.cc
@@ -121,7 +121,7 @@ auto add_hit(struct searchinfo_s * si, uint64_t seqno) -> void
 
       hp->count = 0;
 
-      hp->nwscore = static_cast<int>(si->qseqlen * opt_match);
+      hp->nwscore = static_cast<int>(static_cast<int64_t>(si->qseqlen) * opt_match);
       hp->nwdiff = 0;
       hp->nwgaps = 0;
       hp->nwindels = 0;

--- a/src/search_exact.cc
+++ b/src/search_exact.cc
@@ -428,7 +428,6 @@ auto search_exact_thread_run(uint64_t t) -> void
 
       if (fastx_next(query_fastx_h, (opt_notrunclabels == 0), chrmap_no_change_vector.data()))
         {
-          if (not fastx_query_length_ok(query_fastx_h)) { break; }
           char const * qhead = fastx_get_header(query_fastx_h);
           int const query_head_len = static_cast<int>(fastx_get_header_length(query_fastx_h));
           char const * qseq = fastx_get_sequence(query_fastx_h);

--- a/src/sintax.cc
+++ b/src/sintax.cc
@@ -498,6 +498,7 @@ auto sintax_thread_run(uint64_t const t) -> void
                      opt_notrunclabels == 0,
                      chrmap_no_change_vector.data()))
         {
+          if (not fastx_query_length_ok(query_fastx_h)) { break; }
           auto const * qhead = fastx_get_header(query_fastx_h);
           int const query_head_len = static_cast<int>(fastx_get_header_length(query_fastx_h));
           auto const * qseq = fastx_get_sequence(query_fastx_h);

--- a/src/sintax.cc
+++ b/src/sintax.cc
@@ -519,14 +519,14 @@ auto sintax_thread_run(uint64_t const t) -> void
 
               if (si->query_head_len + 1 > si->query_head_alloc)
                 {
-                  si->query_head_alloc = si->query_head_len + 2001;
+                  si->query_head_alloc = si->query_head_len + buffer_headroom;
                   si->query_head = static_cast<char *>(
                     xrealloc(si->query_head, static_cast<size_t>(si->query_head_alloc)));
                 }
 
               if (si->qseqlen + 1 > si->seq_alloc)
                 {
-                  si->seq_alloc = si->qseqlen + 2001;
+                  si->seq_alloc = si->qseqlen + buffer_headroom;
                   si->qsequence = static_cast<char *>(
                     xrealloc(si->qsequence, static_cast<size_t>(si->seq_alloc)));
                 }

--- a/src/sintax.cc
+++ b/src/sintax.cc
@@ -498,7 +498,6 @@ auto sintax_thread_run(uint64_t const t) -> void
                      opt_notrunclabels == 0,
                      chrmap_no_change_vector.data()))
         {
-          if (not fastx_query_length_ok(query_fastx_h)) { break; }
           auto const * qhead = fastx_get_header(query_fastx_h);
           int const query_head_len = static_cast<int>(fastx_get_header_length(query_fastx_h));
           auto const * qseq = fastx_get_sequence(query_fastx_h);

--- a/src/udb.cc
+++ b/src/udb.cc
@@ -427,6 +427,10 @@ auto udb_read(const char * filename,
         }
       seqindex[i].header_p = current_index;
       seqindex[i].headerlen = header_index[i + 1] - current_index - 1;
+      if (static_cast<int64_t>(seqindex[i].headerlen) > std::numeric_limits<int>::max() - buffer_headroom)
+        {
+          fatal("UDB file contains a header too long for this version of vsearch");
+        }
       seqindex[i].size = 1;
       last = current_index;
     }
@@ -457,6 +461,11 @@ auto udb_read(const char * filename,
   for (auto i = 0U; i < seqcount; i++)
     {
       unsigned int const sequence_length = sequence_lengths[i];
+
+      if (static_cast<int64_t>(sequence_length) > std::numeric_limits<int>::max() - buffer_headroom)
+        {
+          fatal("UDB file contains a sequence too long for this version of vsearch");
+        }
 
       seqindex[i].seq_p = udb_headerchars + sum;
       seqindex[i].seqlen = sequence_length;

--- a/src/unique.cc
+++ b/src/unique.cc
@@ -102,8 +102,11 @@ struct uhandle_s
   struct bucket_s * hash;
   unsigned int * list;
   unsigned int hash_mask;
-  int size;
-  int alloc;
+  // size and alloc are 64-bit: the hash grows to 2 * sequence length, which
+  // exceeds INT_MAX for sequences above ~1.07 Gnt (the doubling would otherwise
+  // overflow int before reaching the target). See unique_count_hash().
+  int64_t size;
+  int64_t alloc;
 
   uint64_t bitmap_size;
   uint64_t * bitmap;
@@ -264,9 +267,10 @@ auto unique_count_hash(struct uhandle_s * unique_handle,
 {
   /* if necessary, reallocate hash table and list of unique kmers */
 
-  if (unique_handle->alloc < 2 * seqlen)
+  int64_t const needed = 2 * static_cast<int64_t>(seqlen);
+  if (unique_handle->alloc < needed)
     {
-      while (unique_handle->alloc < 2 * seqlen)
+      while (unique_handle->alloc < needed)
         {
           unique_handle->alloc *= 2;
         }
@@ -279,7 +283,7 @@ auto unique_count_hash(struct uhandle_s * unique_handle,
   /* hashtable variant */
 
   unique_handle->size = 1;
-  while (unique_handle->size < 2 * seqlen)
+  while (unique_handle->size < needed)
     {
       unique_handle->size *= 2;
     }

--- a/src/utils/kmer_hash_struct.hpp
+++ b/src/utils/kmer_hash_struct.hpp
@@ -58,6 +58,7 @@
 
 */
 
+#include <cstdint>  // int64_t
 #include <vector>
 
 
@@ -73,7 +74,10 @@ struct kh_handle_s
   static constexpr auto kmer_hash_mask = kmer_hash_allocation - 1U;
   std::vector<struct kh_bucket_s> hash = std::vector<struct kh_bucket_s>(kmer_hash_allocation);
   unsigned int hash_mask = kmer_hash_mask;
-  int size = 0;
-  int alloc = kmer_hash_allocation;
+  // size and alloc are 64-bit: the hash grows to 2 * sequence length, which
+  // exceeds INT_MAX for sequences above ~1.07 Gnt (the doubling would otherwise
+  // overflow int before reaching the target). See kh_insert_kmers().
+  int64_t size = 0;
+  int64_t alloc = kmer_hash_allocation;
   int maxpos = 0;
 };

--- a/src/vsearch.h
+++ b/src/vsearch.h
@@ -197,6 +197,16 @@
 #include "fastq.h"
 #include "dbhash.h"
 
+/* Over-allocation headroom (bytes) for the per-query header and sequence
+   buffers in the search engine: populate_si() grows them to
+   length + buffer_headroom (see searchinfo_s::query_head_alloc / seq_alloc),
+   so a query slightly longer than the previous one does not trigger another
+   realloc. It also fixes the sequence/header length ceiling: --maxseqlength is
+   capped at INT_MAX - buffer_headroom (cli.cc) and fastx_filter_header rejects
+   longer headers, so length + buffer_headroom can never overflow the int size
+   fields. */
+constexpr int buffer_headroom = 2001;
+
 /* options */
 
 extern bool opt_bzip2_decompress;


### PR DESCRIPTION
This hardens the sequence/header length handling against 32-bit integer
overflow on genuinely large records (multi-GB single sequences or headers —
e.g. large assemblies or deeply pooled data). Each length was carried or
computed as `int` in several places; near or above ~2 GB these narrow to a
negative value that mis-sizes buffers and can overflow the heap or corrupt
output. No behaviour changes for normal-sized data.

### What changed

- **Cap `--maxseqlength` at `INT_MAX - 2001`.** The per-query buffers grow to
  `length + 2001`, so this is the largest length that cannot overflow the `int`
  size fields or their realloc headroom. The magic `2001` is factored into a
  named `buffer_headroom` constant. (Previous maximum was `UINT32_MAX`; the
  documented maximum drops from ~4.29 G to ~2.15 G.) Manual updated in both
  systems.

- **Widen length-derived arithmetic that overflows below the cap.** Sites that
  multiply or double a length in `int` (chimera per-alignment sizing and index,
  the MSA profile index, the k-mer hash `2*seqlen` sizing, and the
  `qseqlen*match` exact-search score) now compute in `size_t`/`int64_t`.

- **Bound sequence length at the central FASTA/FASTQ reader.** `fasta_next` /
  `fastq_next` now reject any sequence longer than `INT_MAX - buffer_headroom`
  at the single choke point every read passes through — symmetric with the
  existing header-length guard — so no command can narrow a length to a negative
  `int`. Errors are deferred on worker threads and reported from the main thread,
  matching the existing header/illegal-character handling. Also bounds-checks the
  stored lengths when loading a `.udb`.

- **Compute the total MSA alignment length in 64-bit.** The per-cluster total
  can exceed `INT_MAX` even when each sequence is bounded; a 32-bit accumulator
  wrapped to a wrong length that under-sized the profile/alignment buffers.

### Testing

Default (`-O2`) and debug (`-Wconversion`/`-Wsign-conversion`) builds are clean;
smoke-tested across usearch_global, search_exact, sintax, orient, uchime_ref,
cut, and cluster consensus with normal-sized data unchanged. The >2 GB triggers
themselves aren't practical to exercise in CI (they need multi-GB single
records), so verification is code review plus the normal-size regression suite.