### PR TITLE
Harden the UDB reader against corrupt or crafted files

### DIFF
--- a/src/udb.cc
+++ b/src/udb.cc
@@ -371,6 +371,16 @@ auto udb_read(const char * filename,
   seqcount = buffer[13];
   udb_dbaccel = buffer[6];
 
+  /* The per-sequence header-index and length tables each store 4 bytes
+     per sequence, so a file cannot describe more than filesize/4
+     sequences. Rejecting a larger seqcount also keeps it well clear of
+     the seqcount + 1 wrap when the header index is sized below. */
+
+  if (seqcount > filesize / 4)
+    {
+      fatal("Invalid UDB file");
+    }
+
   if (udb_wordlength != opt_wordlength)
     {
       std::fprintf(stderr, "\nWARNING: Wordlength adjusted to %u as indicated in UDB file\n", udb_wordlength);
@@ -463,6 +473,12 @@ auto udb_read(const char * filename,
     {
       unsigned int const current_index = header_index[i];
       if ((current_index < last) or (current_index >= udb_headerchars))
+        {
+          fatal("Invalid UDB file");
+        }
+      /* Header offsets must strictly increase: an equal (or smaller) next
+         offset would make headerlen (next - current - 1) underflow. */
+      if (header_index[i + 1] <= current_index)
         {
           fatal("Invalid UDB file");
         }

--- a/src/udb.cc
+++ b/src/udb.cc
@@ -287,6 +287,24 @@ auto udb_info(struct Parameters const & parameters) -> void
 }
 
 
+/* Validate-on-load helpers for untrusted UDB header fields.
+
+   The values below are read verbatim from the file, so a crafted or
+   corrupt UDB must be rejected with a clear error rather than allowed to
+   drive an out-of-bounds allocation, index or write. There is no
+   recoverable error channel (fatal() terminates the process), so a
+   violation fatals. */
+
+static auto udb_checked_add(uint64_t const lhs, uint64_t const rhs) -> uint64_t
+{
+  if (lhs > std::numeric_limits<uint64_t>::max() - rhs)
+    {
+      fatal("Invalid UDB file");
+    }
+  return lhs + rhs;
+}
+
+
 auto udb_read(const char * filename,
               bool create_bitmaps,
               bool parse_abundances) -> void
@@ -374,7 +392,16 @@ auto udb_read(const char * filename,
   for (uint64_t i = 0; i < kmerhashsize; i++)
     {
       kmerhash[i] = kmerindexsize;
-      kmerindexsize += kmercount[i];
+      kmerindexsize = udb_checked_add(kmerindexsize, kmercount[i]);
+    }
+
+  /* The word-list section stores 4 bytes per index entry, so a file can
+     hold at most filesize/4 entries; a larger total means the kmercount[]
+     values do not match the on-disk section (padded/corrupt file). */
+
+  if (kmerindexsize > filesize / 4)
+    {
+      fatal("Invalid UDB file");
     }
 
   /* signature */
@@ -391,6 +418,20 @@ auto udb_read(const char * filename,
   kmerindex = static_cast<unsigned int *>(xmalloc(kmerindexsize * 4));
 
   pos += largeread(fd_udb, kmerindex, 4 * kmerindexsize, pos);
+
+  /* Every entry is a sequence number used both as a bit offset in the
+     per-word bitmaps (bitmap_set writes bitmap[value >> 3], no bounds
+     check) and as an index into seqindex/dbindex_map during search. A
+     value >= seqcount is therefore an out-of-bounds write or read, so
+     reject it here rather than at use. */
+
+  for (uint64_t i = 0; i < kmerindexsize; i++)
+    {
+      if (kmerindex[i] >= seqcount)
+        {
+          fatal("Invalid UDB file");
+        }
+    }
 
   /* new header */
 
@@ -438,7 +479,7 @@ auto udb_read(const char * filename,
 
   /* headers */
 
-  datap = static_cast<char *>(xmalloc(udb_headerchars + nucleotides + seqcount));
+  datap = static_cast<char *>(xmalloc(udb_checked_add(udb_checked_add(udb_headerchars, nucleotides), seqcount)));
 
   pos += largeread(fd_udb, datap, udb_headerchars, pos);
 


### PR DESCRIPTION
## Summary

`udb_read()` trusted several values read verbatim from a `.udb` file and used
them as allocation sizes, loop bounds, or indices without validation, so a
corrupt or crafted database could drive out-of-bounds memory access. This adds
the missing bounds checks; valid databases are unaffected.

Two commits:

### 1. Validate UDB fields on load
- **Sequence numbers (`kmerindex`).** Each entry is used both as a bit offset in
  `bitmap_set()` (which writes `bitmap[value >> 3]` with no bounds check) and as
  an index into `seqindex`/`dbindex_map` during search. A value `>= seqcount` was
  therefore a near-arbitrary out-of-bounds heap write (with bitmaps enabled) or
  read. Every entry is now rejected unless `< seqcount`, right after the section
  is read.
- **`kmerindexsize`.** It is accumulated from the per-word `kmercount[]` values
  with no consistency check. The running sum is now overflow-checked and rejected
  if it exceeds `filesize / 4` (the word list stores 4 bytes per entry, so a
  larger total cannot match the file).
- **`datap` allocation.** `xmalloc(udb_headerchars + nucleotides + seqcount)`
  summed three file-derived 64-bit values with no overflow guard; the addition
  now goes through an overflow-checked helper.

### 2. Tighten header-index validation
- Header offsets were only required to be non-decreasing, so two equal
  consecutive offsets slipped through and made `headerlen = next - current - 1`
  underflow to ~4 GB. Offsets are now required to strictly increase.
- `seqcount` was only checked `!= 0`; it is now bounded by `filesize / 4`, which
  also closes a `seqcount + 1` wrap at `UINT_MAX` when the header-index vector is
  sized.

## Verification

- A `makeudb_usearch` → `usearch_global` / `cluster_fast` round-trip on valid
  data produces unchanged results (exit 0).
- Crafted databases — an inflated `kmerindex[0]`, an inflated `kmercount[0]`, and
  equal consecutive header offsets — now fail with a clear `Invalid UDB file`
  (exit 1).
- Builds clean under `-O2` and `--enable-debug` (including
  `-Wconversion`/`-Wsign-conversion`).

These triggers need multi-GB or deliberately malformed inputs and aren't part of
the normal test suite; verification is by code review plus the round-trip above.