### PR TITLE
Detect write/flush/close errors on output streams

### DIFF
--- a/src/allpairs.cc
+++ b/src/allpairs.cc
@@ -706,43 +706,43 @@ auto allpairs_global(struct Parameters const & parameters, char const * cmdline,
   db_free();
   if (opt_matched != nullptr)
     {
-      std::fclose(fp_matched);
+      fclose_output(fp_matched);
     }
   if (opt_notmatched != nullptr)
     {
-      std::fclose(fp_notmatched);
+      fclose_output(fp_notmatched);
     }
   if (opt_fastapairs != nullptr)
     {
-      std::fclose(fp_fastapairs);
+      fclose_output(fp_fastapairs);
     }
   if (opt_qsegout != nullptr)
     {
-      std::fclose(fp_qsegout);
+      fclose_output(fp_qsegout);
     }
   if (opt_tsegout != nullptr)
     {
-      std::fclose(fp_tsegout);
+      fclose_output(fp_tsegout);
     }
   if (fp_uc != nullptr)
     {
-      std::fclose(fp_uc);
+      fclose_output(fp_uc);
     }
   if (fp_blast6out != nullptr)
     {
-      std::fclose(fp_blast6out);
+      fclose_output(fp_blast6out);
     }
   if (fp_userout != nullptr)
     {
-      std::fclose(fp_userout);
+      fclose_output(fp_userout);
     }
   if (fp_alnout != nullptr)
     {
-      std::fclose(fp_alnout);
+      fclose_output(fp_alnout);
     }
   if (fp_samout != nullptr)
     {
-      std::fclose(fp_samout);
+      fclose_output(fp_samout);
     }
   show_rusage();
 

--- a/src/chimera.cc
+++ b/src/chimera.cc
@@ -2335,7 +2335,7 @@ auto close_chimera_file(std::FILE * output_stream) -> void
 {
   if (output_stream != nullptr)
     {
-      std::fclose(output_stream);
+      fclose_output(output_stream);
     }
 }
 

--- a/src/cluster.cc
+++ b/src/cluster.cc
@@ -1433,7 +1433,7 @@ auto cluster(char const * dbname,
               /* close previous (except for first time) and open new file */
               if (lastcluster != -1)
                 {
-                  std::fclose(fp_clusters);
+                  fclose_output(fp_clusters);
                 }
 
               ordinal = 0;
@@ -1468,7 +1468,7 @@ auto cluster(char const * dbname,
       /* performed with the last sequence */
       if (opt_clusters != nullptr)
         {
-          std::fclose(fp_clusters);
+          fclose_output(fp_clusters);
         }
     }
 
@@ -1605,17 +1605,17 @@ auto cluster(char const * dbname,
 
       if (fp_profile != nullptr)
         {
-          std::fclose(fp_profile);
+          fclose_output(fp_profile);
         }
 
       if (fp_msaout != nullptr)
         {
-          std::fclose(fp_msaout);
+          fclose_output(fp_msaout);
         }
 
       if (fp_consout != nullptr)
         {
-          std::fclose(fp_consout);
+          fclose_output(fp_consout);
         }
     }
 
@@ -1636,67 +1636,67 @@ auto cluster(char const * dbname,
   if (fp_biomout != nullptr)
     {
       otutable_print_biomout(fp_biomout);
-      std::fclose(fp_biomout);
+      fclose_output(fp_biomout);
     }
 
   if (fp_otutabout != nullptr)
     {
       otutable_print_otutabout(fp_otutabout);
-      std::fclose(fp_otutabout);
+      fclose_output(fp_otutabout);
     }
 
   if (fp_mothur_shared_out != nullptr)
     {
       otutable_print_mothur_shared_out(fp_mothur_shared_out);
-      std::fclose(fp_mothur_shared_out);
+      fclose_output(fp_mothur_shared_out);
     }
 
   otutable_done();
 
   if (opt_matched != nullptr)
     {
-      std::fclose(fp_matched);
+      fclose_output(fp_matched);
     }
   if (opt_notmatched != nullptr)
     {
-      std::fclose(fp_notmatched);
+      fclose_output(fp_notmatched);
     }
   if (opt_fastapairs != nullptr)
     {
-      std::fclose(fp_fastapairs);
+      fclose_output(fp_fastapairs);
     }
   if (opt_qsegout != nullptr)
     {
-      std::fclose(fp_qsegout);
+      fclose_output(fp_qsegout);
     }
   if (opt_tsegout != nullptr)
     {
-      std::fclose(fp_tsegout);
+      fclose_output(fp_tsegout);
     }
   if (fp_blast6out != nullptr)
     {
-      std::fclose(fp_blast6out);
+      fclose_output(fp_blast6out);
     }
   if (fp_userout != nullptr)
     {
-      std::fclose(fp_userout);
+      fclose_output(fp_userout);
       clean_up(); // free userfields allocation
     }
   if (fp_alnout != nullptr)
     {
-      std::fclose(fp_alnout);
+      fclose_output(fp_alnout);
     }
   if (fp_samout != nullptr)
     {
-      std::fclose(fp_samout);
+      fclose_output(fp_samout);
     }
   if (fp_uc != nullptr)
     {
-      std::fclose(fp_uc);
+      fclose_output(fp_uc);
     }
   if (fp_centroids != nullptr)
     {
-      std::fclose(fp_centroids);
+      fclose_output(fp_centroids);
     }
 
   dbindex_free();

--- a/src/cut.cc
+++ b/src/cut.cc
@@ -439,7 +439,7 @@ namespace {
         fastaout.cut.forward.handle, fastaout.discarded.forward.handle,
         fastaout.cut.reverse.handle, fastaout.discarded.reverse.handle}) {
       if (fp_outputfile != nullptr) {
-        static_cast<void>(std::fclose(fp_outputfile));
+        static_cast<void>(fclose_output(fp_outputfile));
       }
     }
   }

--- a/src/dbindex.cc
+++ b/src/dbindex.cc
@@ -207,7 +207,7 @@ auto dbindex_prepare(int use_bitmap, int seqmask) -> void
       fprint_kmer(f, 8, kmer);
       std::fprintf(f, "\t%d\t%d\n", kmer, kmercount[kmer]);
     }
-  std::fclose(f);
+  fclose_output(f);
 #endif
 
   /* determine minimum kmer count for bitmap usage */

--- a/src/derep.cc
+++ b/src/derep.cc
@@ -799,7 +799,7 @@ auto derep(struct Parameters const & parameters, char * input_filename, bool con
         }
 
       progress_done();
-      std::fclose(fp_fastaout);
+      fclose_output(fp_fastaout);
     }
 
   if (parameters.opt_fastqout != nullptr)
@@ -832,7 +832,7 @@ auto derep(struct Parameters const & parameters, char * input_filename, bool con
         }
 
       progress_done();
-      std::fclose(fp_fastqout);
+      fclose_output(fp_fastqout);
     }
 
   show_rusage();
@@ -871,7 +871,7 @@ auto derep(struct Parameters const & parameters, char * input_filename, bool con
                   i, cluster.size, cluster.header);
           progress_update(i);
         }
-      std::fclose(fp_uc);
+      fclose_output(fp_uc);
       progress_done();
     }
 
@@ -910,7 +910,7 @@ auto derep(struct Parameters const & parameters, char * input_filename, bool con
 
           progress_update(i);
         }
-      std::fclose(fp_tabbedout);
+      fclose_output(fp_tabbedout);
       progress_done();
     }
 

--- a/src/derep_prefix.cc
+++ b/src/derep_prefix.cc
@@ -468,7 +468,7 @@ auto derep_prefix(struct Parameters const & parameters) -> void
         }
 
       progress_done();
-      std::fclose(fp_output);
+      fclose_output(fp_output);
     }
 
   show_rusage();
@@ -507,7 +507,7 @@ auto derep_prefix(struct Parameters const & parameters) -> void
                   i, bp.size, db_getheader(bp.seqno_first));
           progress_update(static_cast<uint64_t>(i));
         }
-      std::fclose(fp_uc);
+      fclose_output(fp_uc);
       progress_done();
       show_rusage();
     }

--- a/src/derep_smallmem.cc
+++ b/src/derep_smallmem.cc
@@ -621,7 +621,7 @@ auto derep_smallmem(struct Parameters const & parameters) -> void
     }
   progress_done();
   fastx_close(h2);
-  std::fclose(fp_fastaout);
+  fclose_output(fp_fastaout);
 
   show_rusage();
 

--- a/src/eestats.cc
+++ b/src/eestats.cc
@@ -403,7 +403,7 @@ auto fastq_eestats(struct Parameters const & parameters) -> void
               min_ee, low_ee, med_ee, mean_ee, hi_ee, max_ee);
     }
 
-  std::fclose(fp_output);
+  fclose_output(fp_output);
 
   fastq_close(h);
 }
@@ -587,7 +587,7 @@ auto fastq_eestats2(struct Parameters const & parameters) -> void
         }
     }
 
-  std::fclose(fp_output);
+  fclose_output(fp_output);
 
   fastq_close(h);
 }

--- a/src/fastq_join.cc
+++ b/src/fastq_join.cc
@@ -155,7 +155,7 @@ namespace {
   auto close_output_files(struct output_files const & outfiles) -> void {
     for (auto * fp_outputfile : {outfiles.fasta.handle, outfiles.fastq.handle}) {
       if (fp_outputfile != nullptr) {
-        static_cast<void>(std::fclose(fp_outputfile));
+        static_cast<void>(fclose_output(fp_outputfile));
       }
     }
   }

--- a/src/fastq_mergepairs.cc
+++ b/src/fastq_mergepairs.cc
@@ -1765,31 +1765,31 @@ auto fastq_mergepairs(struct Parameters const & parameters) -> void
 
   if (opt_eetabbedout != nullptr)
     {
-      std::fclose(fp_eetabbedout);
+      fclose_output(fp_eetabbedout);
     }
   if (opt_fastaout_notmerged_rev != nullptr)
     {
-      std::fclose(fp_fastaout_notmerged_rev);
+      fclose_output(fp_fastaout_notmerged_rev);
     }
   if (opt_fastaout_notmerged_fwd != nullptr)
     {
-      std::fclose(fp_fastaout_notmerged_fwd);
+      fclose_output(fp_fastaout_notmerged_fwd);
     }
   if (opt_fastqout_notmerged_rev != nullptr)
     {
-      std::fclose(fp_fastqout_notmerged_rev);
+      fclose_output(fp_fastqout_notmerged_rev);
     }
   if (opt_fastqout_notmerged_fwd != nullptr)
     {
-      std::fclose(fp_fastqout_notmerged_fwd);
+      fclose_output(fp_fastqout_notmerged_fwd);
     }
   if (opt_fastaout != nullptr)
     {
-      std::fclose(fp_fastaout);
+      fclose_output(fp_fastaout);
     }
   if (opt_fastqout != nullptr)
     {
-      std::fclose(fp_fastqout);
+      fclose_output(fp_fastqout);
     }
 
   fastq_close(fastq_rev);

--- a/src/fastqops.cc
+++ b/src/fastqops.cc
@@ -201,12 +201,12 @@ auto fastx_revcomp(struct Parameters const & parameters) -> void
 
   if (parameters.opt_fastaout != nullptr)
     {
-      std::fclose(fp_fastaout);
+      fclose_output(fp_fastaout);
     }
 
   if (parameters.opt_fastqout != nullptr)
     {
-      std::fclose(fp_fastqout);
+      fclose_output(fp_fastqout);
     }
 
   fastx_close(input_handle);
@@ -311,6 +311,6 @@ auto fastq_convert(struct Parameters const & parameters) -> void
 
   progress_done();
 
-  std::fclose(fp_fastqout);
+  fclose_output(fp_fastqout);
   fastq_close(input_handle);
 }

--- a/src/fastx_syncpairs.cc
+++ b/src/fastx_syncpairs.cc
@@ -169,7 +169,7 @@ namespace {
                               & outfiles.orphans_fwd, & outfiles.orphans_rev}) {
       for (auto * handle : {pair->fasta.handle, pair->fastq.handle}) {
         if (handle != nullptr) {
-          static_cast<void>(std::fclose(handle));
+          static_cast<void>(fclose_output(handle));
         }
       }
     }

--- a/src/filter.cc
+++ b/src/filter.cc
@@ -591,22 +591,22 @@ auto filter(bool const fastq_only, char const * filename) -> void
     {
       if (opt_fastaout_rev != nullptr)
         {
-          std::fclose(fp_fastaout_rev);
+          fclose_output(fp_fastaout_rev);
         }
 
       if (opt_fastqout_rev != nullptr)
         {
-          std::fclose(fp_fastqout_rev);
+          fclose_output(fp_fastqout_rev);
         }
 
       if (opt_fastaout_discarded_rev != nullptr)
         {
-          std::fclose(fp_fastaout_discarded_rev);
+          fclose_output(fp_fastaout_discarded_rev);
         }
 
       if (opt_fastqout_discarded_rev != nullptr)
         {
-          std::fclose(fp_fastqout_discarded_rev);
+          fclose_output(fp_fastqout_discarded_rev);
         }
 
       fastx_close(reverse_handle);
@@ -614,22 +614,22 @@ auto filter(bool const fastq_only, char const * filename) -> void
 
   if (opt_fastaout != nullptr)
     {
-      std::fclose(fp_fastaout);
+      fclose_output(fp_fastaout);
     }
 
   if (opt_fastqout != nullptr)
     {
-      std::fclose(fp_fastqout);
+      fclose_output(fp_fastqout);
     }
 
   if (opt_fastaout_discarded != nullptr)
     {
-      std::fclose(fp_fastaout_discarded);
+      fclose_output(fp_fastaout_discarded);
     }
 
   if (opt_fastqout_discarded != nullptr)
     {
-      std::fclose(fp_fastqout_discarded);
+      fclose_output(fp_fastqout_discarded);
     }
 
   fastx_close(forward_handle);

--- a/src/getseq.cc
+++ b/src/getseq.cc
@@ -575,22 +575,22 @@ auto getseq(struct Parameters const & parameters, char const * filename) -> void
 
   if (opt_fastaout != nullptr)
     {
-      std::fclose(fp_fastaout);
+      fclose_output(fp_fastaout);
     }
 
   if (opt_fastqout != nullptr)
     {
-      std::fclose(fp_fastqout);
+      fclose_output(fp_fastqout);
     }
 
   if (opt_notmatched != nullptr)
     {
-      std::fclose(fp_notmatched);
+      fclose_output(fp_notmatched);
     }
 
   if (opt_notmatchedfq != nullptr)
     {
-      std::fclose(fp_notmatchedfq);
+      fclose_output(fp_notmatchedfq);
     }
 
   fastx_close(h1);

--- a/src/mask.cc
+++ b/src/mask.cc
@@ -464,10 +464,10 @@ auto fastx_mask(struct Parameters const & parameters) -> void
 
   if (fp_fastaout != nullptr)
     {
-      std::fclose(fp_fastaout);
+      fclose_output(fp_fastaout);
     }
   if (fp_fastqout != nullptr)
     {
-      std::fclose(fp_fastqout);
+      fclose_output(fp_fastqout);
     }
 }

--- a/src/orient.cc
+++ b/src/orient.cc
@@ -447,19 +447,19 @@ auto orient(struct Parameters const & parameters) -> void
 
   if (opt_tabbedout != nullptr)
     {
-      std::fclose(fp_tabbedout);
+      fclose_output(fp_tabbedout);
     }
   if (opt_notmatched != nullptr)
     {
-      std::fclose(fp_notmatched);
+      fclose_output(fp_notmatched);
     }
   if (opt_fastqout != nullptr)
     {
-      std::fclose(fp_fastqout);
+      fclose_output(fp_fastqout);
     }
   if (opt_fastaout != nullptr)
     {
-      std::fclose(fp_fastaout);
+      fclose_output(fp_fastaout);
     }
 
   fasta_close(query_h);

--- a/src/search.cc
+++ b/src/search.cc
@@ -749,48 +749,48 @@ auto search_done() -> void
 
   if (opt_lcaout != nullptr)
     {
-      std::fclose(fp_lcaout);
+      fclose_output(fp_lcaout);
     }
   if (opt_matched != nullptr)
     {
-      std::fclose(fp_matched);
+      fclose_output(fp_matched);
     }
   if (opt_notmatched != nullptr)
     {
-      std::fclose(fp_notmatched);
+      fclose_output(fp_notmatched);
     }
   if (opt_fastapairs != nullptr)
     {
-      std::fclose(fp_fastapairs);
+      fclose_output(fp_fastapairs);
     }
   if (opt_qsegout != nullptr)
     {
-      std::fclose(fp_qsegout);
+      fclose_output(fp_qsegout);
     }
   if (opt_tsegout != nullptr)
     {
-      std::fclose(fp_tsegout);
+      fclose_output(fp_tsegout);
     }
   if (fp_uc != nullptr)
     {
-      std::fclose(fp_uc);
+      fclose_output(fp_uc);
     }
   if (fp_blast6out != nullptr)
     {
-      std::fclose(fp_blast6out);
+      fclose_output(fp_blast6out);
     }
   if (fp_userout != nullptr)
     {
-      std::fclose(fp_userout);
+      fclose_output(fp_userout);
       clean_up(); // free userfields allocation
     }
   if (fp_alnout != nullptr)
     {
-      std::fclose(fp_alnout);
+      fclose_output(fp_alnout);
     }
   if (fp_samout != nullptr)
     {
-      std::fclose(fp_samout);
+      fclose_output(fp_samout);
     }
   show_rusage();
 }
@@ -925,19 +925,19 @@ auto usearch_global(struct Parameters const & parameters, char const * cmdline, 
   if (opt_biomout != nullptr)
     {
       otutable_print_biomout(fp_biomout);
-      std::fclose(fp_biomout);
+      fclose_output(fp_biomout);
     }
 
   if (opt_otutabout != nullptr)
     {
       otutable_print_otutabout(fp_otutabout);
-      std::fclose(fp_otutabout);
+      fclose_output(fp_otutabout);
     }
 
   if (opt_mothur_shared_out != nullptr)
     {
       otutable_print_mothur_shared_out(fp_mothur_shared_out);
-      std::fclose(fp_mothur_shared_out);
+      fclose_output(fp_mothur_shared_out);
     }
 
   otutable_done();
@@ -992,11 +992,11 @@ auto usearch_global(struct Parameters const & parameters, char const * cmdline, 
 
   if (opt_dbmatched != nullptr)
     {
-      std::fclose(fp_dbmatched);
+      fclose_output(fp_dbmatched);
     }
   if (opt_dbnotmatched != nullptr)
     {
-      std::fclose(fp_dbnotmatched);
+      fclose_output(fp_dbnotmatched);
     }
 
   search_done();

--- a/src/search_exact.cc
+++ b/src/search_exact.cc
@@ -746,52 +746,52 @@ auto search_exact_done() -> void
 
   if (opt_dbmatched != nullptr)
     {
-      std::fclose(fp_dbmatched);
+      fclose_output(fp_dbmatched);
     }
   if (opt_dbnotmatched != nullptr)
     {
-      std::fclose(fp_dbnotmatched);
+      fclose_output(fp_dbnotmatched);
     }
   if (opt_matched != nullptr)
     {
-      std::fclose(fp_matched);
+      fclose_output(fp_matched);
     }
   if (opt_notmatched != nullptr)
     {
-      std::fclose(fp_notmatched);
+      fclose_output(fp_notmatched);
     }
   if (opt_fastapairs != nullptr)
     {
-      std::fclose(fp_fastapairs);
+      fclose_output(fp_fastapairs);
     }
   if (opt_qsegout != nullptr)
     {
-      std::fclose(fp_qsegout);
+      fclose_output(fp_qsegout);
     }
   if (opt_tsegout != nullptr)
     {
-      std::fclose(fp_tsegout);
+      fclose_output(fp_tsegout);
     }
   if (fp_uc != nullptr)
     {
-      std::fclose(fp_uc);
+      fclose_output(fp_uc);
     }
   if (fp_blast6out != nullptr)
     {
-      std::fclose(fp_blast6out);
+      fclose_output(fp_blast6out);
     }
   if (fp_userout != nullptr)
     {
-      std::fclose(fp_userout);
+      fclose_output(fp_userout);
       clean_up(); // free userfields allocation
     }
   if (fp_alnout != nullptr)
     {
-      std::fclose(fp_alnout);
+      fclose_output(fp_alnout);
     }
   if (fp_samout != nullptr)
     {
-      std::fclose(fp_samout);
+      fclose_output(fp_samout);
     }
 
   show_rusage();
@@ -903,19 +903,19 @@ auto search_exact(struct Parameters const & parameters, char const * cmdline, ch
   if (fp_biomout != nullptr)
     {
       otutable_print_biomout(fp_biomout);
-      std::fclose(fp_biomout);
+      fclose_output(fp_biomout);
     }
 
   if (fp_otutabout != nullptr)
     {
       otutable_print_otutabout(fp_otutabout);
-      std::fclose(fp_otutabout);
+      fclose_output(fp_otutabout);
     }
 
   if (fp_mothur_shared_out != nullptr)
     {
       otutable_print_mothur_shared_out(fp_mothur_shared_out);
-      std::fclose(fp_mothur_shared_out);
+      fclose_output(fp_mothur_shared_out);
     }
 
   otutable_done();

--- a/src/sff_convert.cc
+++ b/src/sff_convert.cc
@@ -628,7 +628,7 @@ auto sff_convert(struct Parameters const & parameters) -> void
 
   check_for_additional_tail_data(fp_sff.get(), parameters);  // rename to warn_if_additional_tail_data()?
 
-  std::fclose(fp_fastqout);
+  fclose_output(fp_fastqout);
 
   if (not parameters.opt_quiet) {
     write_report(stderr, sff_header, sff_stats, index_kind.data());

--- a/src/sintax.cc
+++ b/src/sintax.cc
@@ -751,7 +751,7 @@ auto sintax(struct Parameters const & parameters) -> void
     }
 
   fastx_close(query_fastx_h);
-  std::fclose(fp_tabbedout);
+  fclose_output(fp_tabbedout);
 
   dbindex_free();
   db_free();

--- a/src/subsample.cc
+++ b/src/subsample.cc
@@ -362,7 +362,7 @@ auto close_output_files(struct file_types const & ouput_files) -> void {
            ouput_files.fasta.kept.handle, ouput_files.fastq.kept.handle,
            ouput_files.fasta.lost.handle, ouput_files.fastq.lost.handle}) {
     if (fp_outputfile != nullptr) {
-      static_cast<void>(std::fclose(fp_outputfile));
+      static_cast<void>(fclose_output(fp_outputfile));
     }
   }
 }

--- a/src/udb.cc
+++ b/src/udb.cc
@@ -718,7 +718,7 @@ auto udb_fasta(struct Parameters const & parameters) -> void
       progress_update(i + 1);
     }
   progress_done();
-  std::fclose(fp_output);
+  fclose_output(fp_output);
 
   dbindex_free();
   db_free();

--- a/src/util.cc
+++ b/src/util.cc
@@ -415,3 +415,24 @@ auto fopen_output(char const * filename) -> std::FILE *
     }
   return std::fopen(filename, "w");
 }
+
+
+auto fclose_output(std::FILE * stream) -> void
+{
+  if (stream == nullptr)
+    {
+      return;
+    }
+  /* A write error (full disk, quota, broken pipe) is often deferred by stdio
+     until the buffer is flushed, so check fflush and the stream error flag
+     before closing; fclose itself also flushes and can report the same error.
+     Either way, fail loudly rather than leave a silently truncated output. */
+  if ((std::fflush(stream) != 0) or (std::ferror(stream) != 0))
+    {
+      fatal("Unable to write to output file (disk full, quota exceeded, or broken pipe?)");
+    }
+  if (std::fclose(stream) != 0)
+    {
+      fatal("Unable to close output file (disk full or quota exceeded?)");
+    }
+}

--- a/src/util.h
+++ b/src/util.h
@@ -177,3 +177,10 @@ auto fprint_seq_digest_sha1(std::FILE * output_handle, char const * seq, int seq
 auto fprint_seq_digest_md5(std::FILE * output_handle, char const * seq, int seqlen) -> void;
 
 auto fopen_output(char const * filename) -> std::FILE *;
+
+/* Close an output stream, surfacing any deferred write error (full disk,
+   quota, broken pipe) that stdio buffered, instead of silently producing a
+   truncated file. Safe to call with a null handle. Use for every FILE * opened
+   with fopen_output(); do NOT use on input streams (a prior read error would
+   make it fatal spuriously). */
+auto fclose_output(std::FILE * stream) -> void;

--- a/src/utils/open_file.cpp
+++ b/src/utils/open_file.cpp
@@ -135,11 +135,27 @@ auto open_input_file(char const * filename) -> FileHandle {
 }
 
 
+auto CheckedCloseOutputHandle::operator()(std::FILE * file_handle) -> void {
+  if (file_handle == nullptr) {
+    return;
+  }
+  /* A write error (full disk, quota, broken pipe) is often deferred by stdio
+     until the buffer is flushed, so check fflush and the error flag before
+     closing; fclose also flushes and can report the same error. Fail loudly
+     rather than leave a silently truncated output file. */
+  if ((std::fflush(file_handle) != 0) or (std::ferror(file_handle) != 0)) {
+    fatal("Unable to write to output file (disk full, quota exceeded, or broken pipe?)");
+  }
+  if (std::fclose(file_handle) != 0) {
+    fatal("Unable to close output file (disk full or quota exceeded?)");
+  }
+}
+
+
 // write_file, file to write, open_output_file, open_ostream
-auto open_output_file(char const * filename) -> FileHandle {
+auto open_output_file(char const * filename) -> OutputFileHandle {
   if (filename == nullptr) {
-    std::FILE * empty = nullptr;
-    return FileHandle{empty};
+    return OutputFileHandle{nullptr};
   }
   auto const mode = ModeString{"w"};  // w: writing, no b?
   /* open the output stream given by filename, but if name is '-' then
@@ -147,7 +163,7 @@ auto open_output_file(char const * filename) -> FileHandle {
   if (std::strcmp(filename, "-") == 0) {
     auto const file_descriptor = dup(STDOUT_FILENO);
     check_file_descriptor(file_descriptor);
-    return open_file_descriptor(file_descriptor, mode);
+    return OutputFileHandle{open_file_descriptor(file_descriptor, mode).release()};
   }
-  return open_file(filename, mode);
+  return OutputFileHandle{open_file(filename, mode).release()};
 }

--- a/src/utils/open_file.hpp
+++ b/src/utils/open_file.hpp
@@ -82,6 +82,17 @@ struct CloseFileHandle {
 using FileHandle = std::unique_ptr<std::FILE, CloseFileHandle>;
 
 
+// Output streams get a checked close: a deferred write error (full disk, quota
+// exceeded, broken pipe) is surfaced as a fatal error rather than left as a
+// silently truncated output file. Input streams keep the plain CloseFileHandle
+// above (a stale read-error flag must not turn into a write failure).
+struct CheckedCloseOutputHandle {
+  auto operator()(std::FILE * file_handle) -> void;  // defined in open_file.cpp
+};
+
+using OutputFileHandle = std::unique_ptr<std::FILE, CheckedCloseOutputHandle>;
+
+
 auto open_input_file(char const * filename) -> FileHandle;
 
-auto open_output_file(char const * filename) -> FileHandle;
+auto open_output_file(char const * filename) -> OutputFileHandle;

--- a/src/vsearch.cc
+++ b/src/vsearch.cc
@@ -1866,7 +1866,7 @@ auto main(int argc, char** argv) -> int
         {
           std::fprintf(fp_log, "Max memory %.1lfGB\n", maxmem / 1024.0);
         }
-      std::fclose(fp_log);
+      fclose_output(fp_log);
     }
 
   if (opt_ee_cutoffs_values != nullptr)
@@ -1874,6 +1874,15 @@ auto main(int argc, char** argv) -> int
       xfree(opt_ee_cutoffs_values);
     }
   opt_ee_cutoffs_values = nullptr;
+
+  /* Output written directly to stdout is not closed through fclose_output, so
+     surface any deferred write error here (full disk, quota, or a broken pipe
+     such as `vsearch ... | head`) rather than exiting 0 with truncated output
+     (I1). */
+  if ((std::fflush(stdout) != 0) or (std::ferror(stdout) != 0))
+    {
+      fatal("Unable to write to standard output (disk full, quota exceeded, or broken pipe?)");
+    }
 
   xfree(cmdline);
   dynlibs_close();


### PR DESCRIPTION
Textual output currently goes through `fprintf`/`fclose` without checking the result, so a full disk, exceeded quota, or broken pipe produces a **silently truncated output file while vsearch still exits 0**.

Route output closing through a checked `fclose_output()` (`fflush` + `ferror` before an equally-checked `fclose`), plus an `fflush`/`ferror` guard at exit, so a deferred write error fails loudly instead of corrupting results. A broken pipe is still delivered as `SIGPIPE` (non-zero exit).