### PR TITLE
Fix typos in code comments

### DIFF
--- a/src/core/attributes.cpp
+++ b/src/core/attributes.cpp
@@ -102,7 +102,7 @@ namespace {
                              int * end) -> bool
   {
     /*
-      Identify the first occurence of the pattern (^|;)size=([0-9]+)(;|$)
+      Identify the first occurrence of the pattern (^|;)size=([0-9]+)(;|$)
       in the header string, where "size=" is the specified attribute.
       If allow_decimal is true, a dot (.) is allowed within the digits.
     */

--- a/src/core/tax.cpp
+++ b/src/core/tax.cpp
@@ -73,7 +73,7 @@ auto tax_parse(char const * header,
                int * tax_end) -> bool
 {
   /*
-    Identify the first occurence of the pattern (^|;)tax=([^;]*)(;|$)
+    Identify the first occurrence of the pattern (^|;)tax=([^;]*)(;|$)
   */
 
   if (header == nullptr)

--- a/src/core/unique.cpp
+++ b/src/core/unique.cpp
@@ -70,8 +70,8 @@
 
 /*
   Find the unique kmers or words in a given sequence.
-  Unique is now defined as all different words occuring at least once.
-  Earlier it was defined as those words occuring exactly once, but
+  Unique is now defined as all different words occurring at least once.
+  Earlier it was defined as those words occurring exactly once, but
   that caused a problem when searching for sequences with many repeats.
 */
 


### PR DESCRIPTION
Fixes spelling typos in code comments. No code change.

- `occuring` should be `occurring` (src/core/unique.cpp, two occurrences)
- `occurence` should be `occurrence` (src/core/tax.cpp, src/core/attributes.cpp)
